### PR TITLE
fix(login): Trim device ID to prevent format exception

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,13 +12,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:window_manager/window_manager.dart';
 
 late SharedPreferences prefs;
-late String? deviceId;
+late String deviceId;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   prefs = await SharedPreferences.getInstance();
-  deviceId = await FlutterUdid.udid;
+  deviceId = (await FlutterUdid.udid).trim();
 
   ResponsiveSizingConfig.instance.setCustomBreakpoints(
     const ScreenBreakpoints(desktop: 1025, tablet: 600, watch: 200),


### PR DESCRIPTION
<details>
<summary>General intro of myself not PR specific :)</summary>
Hey there, nice project! I'm currently in the process of switching to Jellyfin for my music library and found the web app to lack some features. A few days ago I started to add them myself in their frontend but I highly prefer Flutter and as such was pleasantly surprised to see JellyBox :).

I'm actually running mainly Linux and facing some issues at the moment. So expect some more PRs in the near future ;p.

Feel free to comment on anything you don't like in my PRs, I like honest feedback.
</details>

When logging in - at least on Linux - the following exception is thrown on button click:
```
FormatException: Invalid HTTP header field value: "MediaBrowser Client=\"JellyBox Player\", Device=\"Linux\", DeviceId=\"<redacted>\n\", Version=\"1.8.2\"" (at character 98)
flutter: ...ellyBox Player", Device="Linux", DeviceId="<redacted>
```

It seems, the `DeviceId` contains a `\n` which Jellyfin doesn't like. Simple fix contained in this PR is to just trim the ID on retrieval.