### PR TITLE
fix(linux): Title bar not working

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:io' show Platform;
 
+import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_udid/flutter_udid.dart';
@@ -34,12 +35,17 @@ Future<void> main() async {
     );
   }
 
-  if (Platform.isMacOS || Platform.isLinux || Platform.isWindows) {
+  // Window settings
+  const minWindowSize = Size(1280, 800);
+  const initialWindowSize = Size(1440, 1000);
+
+  // Use window_manager package for MacOS & Windows
+  if (Platform.isMacOS || Platform.isWindows) {
     await windowManager.ensureInitialized();
 
     const windowOptions = WindowOptions(
-      size: Size(1440, 1000),
-      minimumSize: Size(1280, 800),
+      size: initialWindowSize,
+      minimumSize: minWindowSize,
       center: true,
       backgroundColor: Colors.transparent,
       skipTaskbar: false,
@@ -69,4 +75,14 @@ Future<void> main() async {
     },
     appRunner: () => runApp(const ProviderScope(child: App(screenFactory: ScreenFactory()))),
   );
+
+  // Use bitsdojo_window for Linux
+  if (Platform.isLinux) {
+    doWhenWindowReady(() {
+      appWindow.size = initialWindowSize;
+      appWindow.minSize = minWindowSize;
+      appWindow.alignment = Alignment.center;
+      appWindow.show();
+    });
+  }
 }

--- a/lib/src/presentation/pages/main_page.dart
+++ b/lib/src/presentation/pages/main_page.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -46,55 +49,74 @@ class _MainPageState extends ConsumerState<MainPage> {
     final currentIndex = widget.shell.currentIndex;
 
     return Scaffold(
-      body: Row(
+      body: Stack(
         children: [
-          Visibility(
-            visible: _device.isDesktop,
-            child: CustomNavigationRail(
-              padding: const EdgeInsets.symmetric(
-                vertical: 30,
-                horizontal: 20,
-              ),
-              selectedItemColor: _theme.colorScheme.primary,
-              unselectedItemColor: _theme.colorScheme.onPrimary,
-              selectedFontSize: 16,
-              unselectedFontSize: 16,
-              leading: const Text(
-                'JellyBox',
-                style: TextStyle(
-                  fontSize: 30,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-              trailing: TextButton.icon(
-                onPressed: () {
-                  ref.read(authProvider.notifier).logout();
-                },
-                icon: const Icon(JPlayer.log_out),
-                label: const Text('Log out'),
-              ),
-              selectedIndex: currentIndex,
-              onDestinationSelected: _navigateToItem,
-              destinations: List.generate(
-                _menuItems.length,
-                (index) => NavigationRailDestination(
-                  icon: Icon(_menuItems.elementAt(index).$1),
-                  label: Text(_menuItems.elementAt(index).$2),
-                  indicatorColor: const Color(0xFF341010),
+          Row(
+            children: [
+              Visibility(
+                visible: _device.isDesktop,
+                child: CustomNavigationRail(
                   padding: const EdgeInsets.symmetric(
-                    vertical: 20,
-                    horizontal: 10,
+                    vertical: 30,
+                    horizontal: 20,
+                  ),
+                  selectedItemColor: _theme.colorScheme.primary,
+                  unselectedItemColor: _theme.colorScheme.onPrimary,
+                  selectedFontSize: 16,
+                  unselectedFontSize: 16,
+                  leading: const Text(
+                    'JellyBox',
+                    style: TextStyle(
+                      fontSize: 30,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  trailing: TextButton.icon(
+                    onPressed: () {
+                      ref.read(authProvider.notifier).logout();
+                    },
+                    icon: const Icon(JPlayer.log_out),
+                    label: const Text('Log out'),
+                  ),
+                  selectedIndex: currentIndex,
+                  onDestinationSelected: _navigateToItem,
+                  destinations: List.generate(
+                    _menuItems.length,
+                    (index) => NavigationRailDestination(
+                      icon: Icon(_menuItems.elementAt(index).$1),
+                      label: Text(_menuItems.elementAt(index).$2),
+                      indicatorColor: const Color(0xFF341010),
+                      padding: const EdgeInsets.symmetric(
+                        vertical: 20,
+                        horizontal: 10,
+                      ),
+                    ),
                   ),
                 ),
               ),
-            ),
+              Expanded(
+                child: Column(
+                  children: [
+                    Expanded(child: widget.shell),
+                    const BottomPlayer(),
+                  ],
+                ),
+              ),
+            ],
           ),
-          Expanded(
-            child: Column(
-              children: [
-                Expanded(child: widget.shell),
-                const BottomPlayer(),
-              ],
+          Visibility(
+            visible: Platform.isLinux,
+            child: WindowTitleBarBox(
+              child: Row(
+                children: [
+                  Expanded(
+                    child: MoveWindow(),
+                  ),
+                  MinimizeWindowButton(),
+                  MaximizeWindowButton(),
+                  CloseWindowButton(),
+                ],
+              ),
             ),
           ),
         ],

--- a/lib/src/presentation/widgets/position_slider.dart
+++ b/lib/src/presentation/widgets/position_slider.dart
@@ -24,7 +24,9 @@ class _PositionSliderState extends ConsumerState<PositionSlider> {
     if (playbackState.status == PlaybackStatus.stopped) return Container();
     return SeekBar(
       duration: playbackState.totalDuration ?? Duration.zero,
-      position: playbackState.position,
+      // Workaround for a bug where negative positions are passed which triggers an assert that stops the debugger
+      // Tracked in #79   
+      position: playbackState.position >= Duration.zero ? playbackState.position : Duration.zero,
       bufferedPosition: playbackState.cacheProgress,
       onChangeEnd: (value) => ref.read(playbackProvider.notifier).seek(value),
     );

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <bitsdojo_window_linux/bitsdojo_window_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <flutter_udid/flutter_udid_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
@@ -14,6 +15,9 @@
 #include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) bitsdojo_window_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "BitsdojoWindowPlugin");
+  bitsdojo_window_plugin_register_with_registrar(bitsdojo_window_linux_registrar);
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  bitsdojo_window_linux
   flutter_secure_storage_linux
   flutter_udid
   media_kit_libs_linux

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -1,5 +1,8 @@
 #include "my_application.h"
 
+// Required by bitsdojo_window, see its README for more information
+#include <bitsdojo_window_linux/bitsdojo_window_plugin.h>
+
 #include <flutter_linux/flutter_linux.h>
 #ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
@@ -47,7 +50,10 @@ static void my_application_activate(GApplication* application) {
     gtk_window_set_title(window, "jplayer");
   }
 
-  gtk_window_set_default_size(window, 1280, 720);
+  // Required by bitsdojo_window, see its README for more information
+  auto bdw = bitsdojo_window_from(window);
+  bdw->setCustomFrame(true);
+  //gtk_window_set_default_size(window, 1280, 720);
   gtk_widget_show(GTK_WIDGET(window));
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import audio_service
 import audio_session
+import bitsdojo_window_macos
 import flutter_secure_storage_macos
 import flutter_udid
 import just_audio
@@ -22,6 +23,7 @@ import window_manager
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioServicePlugin.register(with: registry.registrar(forPlugin: "AudioServicePlugin"))
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
+  BitsdojoWindowPlugin.register(with: registry.registrar(forPlugin: "BitsdojoWindowPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FlutterUdidPlugin.register(with: registry.registrar(forPlugin: "FlutterUdidPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -89,6 +89,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.20"
+  bitsdojo_window:
+    dependency: "direct main"
+    description:
+      name: bitsdojo_window
+      sha256: "88ef7765dafe52d97d7a3684960fb5d003e3151e662c18645c1641c22b873195"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
+  bitsdojo_window_linux:
+    dependency: transitive
+    description:
+      name: bitsdojo_window_linux
+      sha256: "9519c0614f98be733e0b1b7cb15b827007886f6fe36a4fb62cf3d35b9dd578ab"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
+  bitsdojo_window_macos:
+    dependency: transitive
+    description:
+      name: bitsdojo_window_macos
+      sha256: f7c5be82e74568c68c5b8449e2c5d8fd12ec195ecd70745a7b9c0f802bb0268f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
+  bitsdojo_window_platform_interface:
+    dependency: transitive
+    description:
+      name: bitsdojo_window_platform_interface
+      sha256: "65daa015a0c6dba749bdd35a0f092e7a8ba8b0766aa0480eb3ef808086f6e27c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
+  bitsdojo_window_windows:
+    dependency: transitive
+    description:
+      name: bitsdojo_window_windows
+      sha256: fa982cf61ede53f483e50b257344a1c250af231a3cdc93a7064dd6dc0d720b68
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
   boolean_selector:
     dependency: transitive
     description:
@@ -1480,10 +1520,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "8699323b30da4cdbe2aa2e7c9de567a6abd8a97d9a5c850a3c86dcd0b34bbfbf"
+      sha256: ab8b2a7f97543d3db2b506c9d875e637149d48ee0c6a5cb5f5fd6e0dac463792
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.9"
+    version: "0.4.2"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,8 @@ dependencies:
     sdk: flutter
 
   animations: ^2.0.11
-  window_manager: ^0.3.9
+  bitsdojo_window: ^0.1.6
+  window_manager: ^0.4.2
   cupertino_icons: ^1.0.8
   flutter_udid: ^3.0.0
   dropdown_button2: ^2.3.9

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <bitsdojo_window_windows/bitsdojo_window_plugin.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <flutter_udid/flutter_udid_plugin_c_api.h>
 #include <screen_retriever/screen_retriever_plugin.h>
@@ -13,6 +14,8 @@
 #include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  BitsdojoWindowPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("BitsdojoWindowPlugin"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   FlutterUdidPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  bitsdojo_window_windows
   flutter_secure_storage_windows
   flutter_udid
   screen_retriever


### PR DESCRIPTION
> Hint: PR is rebased on main and got a clean diff now

With the `window_manager` package, the application looks - at least on Wayland - like this:

![image](https://github.com/user-attachments/assets/fa50396f-21c7-4cb9-9763-6b64ef96f7a8)

i.e. no minimize/maximize/close buttons. But more importantly, the window is not draggable and sits constantly in the center of the screen.

I tried fixing it by using the `window_manager` package but couldn't find any options to specify a draggable invisible title bar. Only the default system bar could be added on top of the application which then worked as expected, but doesn't fit the barless style.

As such I tried using another library and got the following result with [bitsdojo_window](https://github.com/bitsdojo/bitsdojo_window):

![image](https://github.com/user-attachments/assets/a5c24efe-430e-4397-8279-260f42313e40)

The top part of the application is fully draggable like a normal title bar. Also the buttons on the right work as expected. Only problem currently is that it's not starting correctly centered on my scren, but I've got a weird setup that's maybe confusing it.
I've enabled this for now only for Linux, as such MacOS and Windows should not be affected by this change.

Please check whether you approve of this solution for the moment. I'll test both libraries on another Linux distro in the next days to see how many of the problems are specifically related to my machine and how the changes would affect other environments.