### PR TITLE
Improve auth experience

### DIFF
--- a/lib/src/data/api/jellyfin/jellyfin_api.dart
+++ b/lib/src/data/api/jellyfin/jellyfin_api.dart
@@ -12,6 +12,9 @@ abstract class JellyfinApi {
     String baseUrl,
   }) = _JellyfinApi;
 
+  @GET('/System/Info/Public')
+  Future<HttpResponse<PublicSystemInfoDTO>> getPublicSystemInfo();
+
   @POST('/Users/AuthenticateByName')
   Future<HttpResponse<SignInResultDTO>> signIn({
     @Body() required UserCredentials credentials,

--- a/lib/src/data/api/jellyfin/jellyfin_api.g.dart
+++ b/lib/src/data/api/jellyfin/jellyfin_api.g.dart
@@ -20,6 +20,34 @@ class _JellyfinApi implements JellyfinApi {
   final ParseErrorLogger? errorLogger;
 
   @override
+  Future<HttpResponse<PublicSystemInfoDTO>> getPublicSystemInfo() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<HttpResponse<PublicSystemInfoDTO>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/System/Info/Public',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late PublicSystemInfoDTO _value;
+    try {
+      _value = PublicSystemInfoDTO.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
   Future<HttpResponse<SignInResultDTO>> signIn({
     required UserCredentials credentials,
   }) async {

--- a/lib/src/data/dto/dto.dart
+++ b/lib/src/data/dto/dto.dart
@@ -3,6 +3,7 @@ export 'item/item_dto.dart';
 export 'lyrics/lyrics_dto.dart';
 export 'media/media_source_dto.dart';
 export 'media/media_stream_dto.dart';
+export 'public_system_info/public_system_info_dto.dart';
 export 'session_info/session_info_dto.dart';
 export 'sign_in_result/sign_in_result_dto.dart';
 export 'user/user_dto.dart';

--- a/lib/src/data/dto/public_system_info/public_system_info_dto.dart
+++ b/lib/src/data/dto/public_system_info/public_system_info_dto.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'public_system_info_dto.freezed.dart';
+part 'public_system_info_dto.g.dart';
+
+@freezed
+abstract class PublicSystemInfoDTO with _$PublicSystemInfoDTO {
+  const factory PublicSystemInfoDTO({
+    @JsonKey(name: 'Id') String? id,
+    @JsonKey(name: 'ServerName') String? serverName,
+    @JsonKey(name: 'Version') String? version,
+    @JsonKey(name: 'ProductName') String? productName,
+    @JsonKey(name: 'OperatingSystem') String? operatingSystem,
+    @JsonKey(name: 'LocalAddress') String? localAddress,
+    @JsonKey(name: 'StartupWizardCompleted') bool? startupWizardCompleted,
+  }) = _PublicSystemInfoDTO;
+
+  factory PublicSystemInfoDTO.fromJson(Map<String, dynamic> json) =>
+      _$PublicSystemInfoDTOFromJson(json);
+}

--- a/lib/src/data/dto/public_system_info/public_system_info_dto.freezed.dart
+++ b/lib/src/data/dto/public_system_info/public_system_info_dto.freezed.dart
@@ -1,0 +1,295 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'public_system_info_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PublicSystemInfoDTO {
+
+@JsonKey(name: 'Id') String? get id;@JsonKey(name: 'ServerName') String? get serverName;@JsonKey(name: 'Version') String? get version;@JsonKey(name: 'ProductName') String? get productName;@JsonKey(name: 'OperatingSystem') String? get operatingSystem;@JsonKey(name: 'LocalAddress') String? get localAddress;@JsonKey(name: 'StartupWizardCompleted') bool? get startupWizardCompleted;
+/// Create a copy of PublicSystemInfoDTO
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PublicSystemInfoDTOCopyWith<PublicSystemInfoDTO> get copyWith => _$PublicSystemInfoDTOCopyWithImpl<PublicSystemInfoDTO>(this as PublicSystemInfoDTO, _$identity);
+
+  /// Serializes this PublicSystemInfoDTO to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PublicSystemInfoDTO&&(identical(other.id, id) || other.id == id)&&(identical(other.serverName, serverName) || other.serverName == serverName)&&(identical(other.version, version) || other.version == version)&&(identical(other.productName, productName) || other.productName == productName)&&(identical(other.operatingSystem, operatingSystem) || other.operatingSystem == operatingSystem)&&(identical(other.localAddress, localAddress) || other.localAddress == localAddress)&&(identical(other.startupWizardCompleted, startupWizardCompleted) || other.startupWizardCompleted == startupWizardCompleted));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,serverName,version,productName,operatingSystem,localAddress,startupWizardCompleted);
+
+@override
+String toString() {
+  return 'PublicSystemInfoDTO(id: $id, serverName: $serverName, version: $version, productName: $productName, operatingSystem: $operatingSystem, localAddress: $localAddress, startupWizardCompleted: $startupWizardCompleted)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PublicSystemInfoDTOCopyWith<$Res>  {
+  factory $PublicSystemInfoDTOCopyWith(PublicSystemInfoDTO value, $Res Function(PublicSystemInfoDTO) _then) = _$PublicSystemInfoDTOCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'Id') String? id,@JsonKey(name: 'ServerName') String? serverName,@JsonKey(name: 'Version') String? version,@JsonKey(name: 'ProductName') String? productName,@JsonKey(name: 'OperatingSystem') String? operatingSystem,@JsonKey(name: 'LocalAddress') String? localAddress,@JsonKey(name: 'StartupWizardCompleted') bool? startupWizardCompleted
+});
+
+
+
+
+}
+/// @nodoc
+class _$PublicSystemInfoDTOCopyWithImpl<$Res>
+    implements $PublicSystemInfoDTOCopyWith<$Res> {
+  _$PublicSystemInfoDTOCopyWithImpl(this._self, this._then);
+
+  final PublicSystemInfoDTO _self;
+  final $Res Function(PublicSystemInfoDTO) _then;
+
+/// Create a copy of PublicSystemInfoDTO
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? serverName = freezed,Object? version = freezed,Object? productName = freezed,Object? operatingSystem = freezed,Object? localAddress = freezed,Object? startupWizardCompleted = freezed,}) {
+  return _then(_self.copyWith(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,serverName: freezed == serverName ? _self.serverName : serverName // ignore: cast_nullable_to_non_nullable
+as String?,version: freezed == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
+as String?,productName: freezed == productName ? _self.productName : productName // ignore: cast_nullable_to_non_nullable
+as String?,operatingSystem: freezed == operatingSystem ? _self.operatingSystem : operatingSystem // ignore: cast_nullable_to_non_nullable
+as String?,localAddress: freezed == localAddress ? _self.localAddress : localAddress // ignore: cast_nullable_to_non_nullable
+as String?,startupWizardCompleted: freezed == startupWizardCompleted ? _self.startupWizardCompleted : startupWizardCompleted // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PublicSystemInfoDTO].
+extension PublicSystemInfoDTOPatterns on PublicSystemInfoDTO {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PublicSystemInfoDTO value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PublicSystemInfoDTO() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PublicSystemInfoDTO value)  $default,){
+final _that = this;
+switch (_that) {
+case _PublicSystemInfoDTO():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PublicSystemInfoDTO value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PublicSystemInfoDTO() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'Id')  String? id, @JsonKey(name: 'ServerName')  String? serverName, @JsonKey(name: 'Version')  String? version, @JsonKey(name: 'ProductName')  String? productName, @JsonKey(name: 'OperatingSystem')  String? operatingSystem, @JsonKey(name: 'LocalAddress')  String? localAddress, @JsonKey(name: 'StartupWizardCompleted')  bool? startupWizardCompleted)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PublicSystemInfoDTO() when $default != null:
+return $default(_that.id,_that.serverName,_that.version,_that.productName,_that.operatingSystem,_that.localAddress,_that.startupWizardCompleted);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'Id')  String? id, @JsonKey(name: 'ServerName')  String? serverName, @JsonKey(name: 'Version')  String? version, @JsonKey(name: 'ProductName')  String? productName, @JsonKey(name: 'OperatingSystem')  String? operatingSystem, @JsonKey(name: 'LocalAddress')  String? localAddress, @JsonKey(name: 'StartupWizardCompleted')  bool? startupWizardCompleted)  $default,) {final _that = this;
+switch (_that) {
+case _PublicSystemInfoDTO():
+return $default(_that.id,_that.serverName,_that.version,_that.productName,_that.operatingSystem,_that.localAddress,_that.startupWizardCompleted);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'Id')  String? id, @JsonKey(name: 'ServerName')  String? serverName, @JsonKey(name: 'Version')  String? version, @JsonKey(name: 'ProductName')  String? productName, @JsonKey(name: 'OperatingSystem')  String? operatingSystem, @JsonKey(name: 'LocalAddress')  String? localAddress, @JsonKey(name: 'StartupWizardCompleted')  bool? startupWizardCompleted)?  $default,) {final _that = this;
+switch (_that) {
+case _PublicSystemInfoDTO() when $default != null:
+return $default(_that.id,_that.serverName,_that.version,_that.productName,_that.operatingSystem,_that.localAddress,_that.startupWizardCompleted);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PublicSystemInfoDTO implements PublicSystemInfoDTO {
+  const _PublicSystemInfoDTO({@JsonKey(name: 'Id') this.id, @JsonKey(name: 'ServerName') this.serverName, @JsonKey(name: 'Version') this.version, @JsonKey(name: 'ProductName') this.productName, @JsonKey(name: 'OperatingSystem') this.operatingSystem, @JsonKey(name: 'LocalAddress') this.localAddress, @JsonKey(name: 'StartupWizardCompleted') this.startupWizardCompleted});
+  factory _PublicSystemInfoDTO.fromJson(Map<String, dynamic> json) => _$PublicSystemInfoDTOFromJson(json);
+
+@override@JsonKey(name: 'Id') final  String? id;
+@override@JsonKey(name: 'ServerName') final  String? serverName;
+@override@JsonKey(name: 'Version') final  String? version;
+@override@JsonKey(name: 'ProductName') final  String? productName;
+@override@JsonKey(name: 'OperatingSystem') final  String? operatingSystem;
+@override@JsonKey(name: 'LocalAddress') final  String? localAddress;
+@override@JsonKey(name: 'StartupWizardCompleted') final  bool? startupWizardCompleted;
+
+/// Create a copy of PublicSystemInfoDTO
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PublicSystemInfoDTOCopyWith<_PublicSystemInfoDTO> get copyWith => __$PublicSystemInfoDTOCopyWithImpl<_PublicSystemInfoDTO>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PublicSystemInfoDTOToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PublicSystemInfoDTO&&(identical(other.id, id) || other.id == id)&&(identical(other.serverName, serverName) || other.serverName == serverName)&&(identical(other.version, version) || other.version == version)&&(identical(other.productName, productName) || other.productName == productName)&&(identical(other.operatingSystem, operatingSystem) || other.operatingSystem == operatingSystem)&&(identical(other.localAddress, localAddress) || other.localAddress == localAddress)&&(identical(other.startupWizardCompleted, startupWizardCompleted) || other.startupWizardCompleted == startupWizardCompleted));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,serverName,version,productName,operatingSystem,localAddress,startupWizardCompleted);
+
+@override
+String toString() {
+  return 'PublicSystemInfoDTO(id: $id, serverName: $serverName, version: $version, productName: $productName, operatingSystem: $operatingSystem, localAddress: $localAddress, startupWizardCompleted: $startupWizardCompleted)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PublicSystemInfoDTOCopyWith<$Res> implements $PublicSystemInfoDTOCopyWith<$Res> {
+  factory _$PublicSystemInfoDTOCopyWith(_PublicSystemInfoDTO value, $Res Function(_PublicSystemInfoDTO) _then) = __$PublicSystemInfoDTOCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'Id') String? id,@JsonKey(name: 'ServerName') String? serverName,@JsonKey(name: 'Version') String? version,@JsonKey(name: 'ProductName') String? productName,@JsonKey(name: 'OperatingSystem') String? operatingSystem,@JsonKey(name: 'LocalAddress') String? localAddress,@JsonKey(name: 'StartupWizardCompleted') bool? startupWizardCompleted
+});
+
+
+
+
+}
+/// @nodoc
+class __$PublicSystemInfoDTOCopyWithImpl<$Res>
+    implements _$PublicSystemInfoDTOCopyWith<$Res> {
+  __$PublicSystemInfoDTOCopyWithImpl(this._self, this._then);
+
+  final _PublicSystemInfoDTO _self;
+  final $Res Function(_PublicSystemInfoDTO) _then;
+
+/// Create a copy of PublicSystemInfoDTO
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? serverName = freezed,Object? version = freezed,Object? productName = freezed,Object? operatingSystem = freezed,Object? localAddress = freezed,Object? startupWizardCompleted = freezed,}) {
+  return _then(_PublicSystemInfoDTO(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,serverName: freezed == serverName ? _self.serverName : serverName // ignore: cast_nullable_to_non_nullable
+as String?,version: freezed == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
+as String?,productName: freezed == productName ? _self.productName : productName // ignore: cast_nullable_to_non_nullable
+as String?,operatingSystem: freezed == operatingSystem ? _self.operatingSystem : operatingSystem // ignore: cast_nullable_to_non_nullable
+as String?,localAddress: freezed == localAddress ? _self.localAddress : localAddress // ignore: cast_nullable_to_non_nullable
+as String?,startupWizardCompleted: freezed == startupWizardCompleted ? _self.startupWizardCompleted : startupWizardCompleted // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/src/data/dto/public_system_info/public_system_info_dto.g.dart
+++ b/lib/src/data/dto/public_system_info/public_system_info_dto.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'public_system_info_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PublicSystemInfoDTO _$PublicSystemInfoDTOFromJson(Map<String, dynamic> json) =>
+    _PublicSystemInfoDTO(
+      id: json['Id'] as String?,
+      serverName: json['ServerName'] as String?,
+      version: json['Version'] as String?,
+      productName: json['ProductName'] as String?,
+      operatingSystem: json['OperatingSystem'] as String?,
+      localAddress: json['LocalAddress'] as String?,
+      startupWizardCompleted: json['StartupWizardCompleted'] as bool?,
+    );
+
+Map<String, dynamic> _$PublicSystemInfoDTOToJson(
+  _PublicSystemInfoDTO instance,
+) => <String, dynamic>{
+  'Id': instance.id,
+  'ServerName': instance.serverName,
+  'Version': instance.version,
+  'ProductName': instance.productName,
+  'OperatingSystem': instance.operatingSystem,
+  'LocalAddress': instance.localAddress,
+  'StartupWizardCompleted': instance.startupWizardCompleted,
+};

--- a/lib/src/data/providers/dio_provider.dart
+++ b/lib/src/data/providers/dio_provider.dart
@@ -6,7 +6,6 @@ import 'package:jplayer/main.dart';
 import 'package:jplayer/src/config/constants.dart';
 import 'package:jplayer/src/core/exceptions/exceptions.dart';
 
-
 String getCurrentPlatformName() {
   if (Platform.isAndroid) {
     return 'Android';
@@ -52,7 +51,8 @@ InterceptorsWrapper interceptor = InterceptorsWrapper(
           handler.next(error.copyWith(error: NetworkException.cancel()));
           return;
         }
-        final err = error.response?.data as String?;
+        final data = error.response?.data;
+        final err = (data is String) ? data : null;
         handler.next(
           error.copyWith(
             error: NetworkException.badResponse(

--- a/lib/src/data/providers/providers.dart
+++ b/lib/src/data/providers/providers.dart
@@ -4,4 +4,5 @@ export 'jellyfin_api_provider.dart';
 export 'playback_storage_provider.dart';
 export 'search_provider.dart';
 export 'secure_storage_provider.dart';
+export 'server_probe_provider.dart';
 export 'shared_preferences_provider.dart';

--- a/lib/src/data/providers/server_probe_provider.dart
+++ b/lib/src/data/providers/server_probe_provider.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jplayer/src/data/services/server_probe_service.dart';
+
+final serverProbeServiceProvider = Provider<ServerProbeService>(
+  (ref) => ServerProbeService(),
+);

--- a/lib/src/data/services/server_probe_service.dart
+++ b/lib/src/data/services/server_probe_service.dart
@@ -1,0 +1,39 @@
+import 'package:dio/dio.dart';
+import 'package:jplayer/src/data/api/api.dart';
+import 'package:jplayer/src/data/dto/dto.dart';
+
+String normalizeServerUrl(String url) {
+  final trimmed = url.trim();
+  if (RegExp('^https?://', caseSensitive: false).hasMatch(trimmed)) {
+    return trimmed;
+  }
+  return 'http://$trimmed';
+}
+
+class ServerProbeService {
+  ServerProbeService({Dio? client})
+    : _client =
+          client ??
+          Dio(
+            BaseOptions(
+              connectTimeout: const Duration(seconds: 6),
+              receiveTimeout: const Duration(seconds: 6),
+              contentType: 'application/json',
+            ),
+          );
+
+  final Dio _client;
+
+  Future<PublicSystemInfoDTO?> probe(String serverUrl) async {
+    try {
+      final response = await JellyfinApi(
+        _client,
+        baseUrl: serverUrl,
+      ).getPublicSystemInfo();
+      final info = response.data;
+      return (info.id != null && info.version != null) ? info : null;
+    } on Object {
+      return null;
+    }
+  }
+}

--- a/lib/src/data/services/server_probe_service.dart
+++ b/lib/src/data/services/server_probe_service.dart
@@ -2,12 +2,26 @@ import 'package:dio/dio.dart';
 import 'package:jplayer/src/data/api/api.dart';
 import 'package:jplayer/src/data/dto/dto.dart';
 
+final _schemeRegExp = RegExp('^https?://', caseSensitive: false);
+
 String normalizeServerUrl(String url) {
   final trimmed = url.trim();
-  if (RegExp('^https?://', caseSensitive: false).hasMatch(trimmed)) {
-    return trimmed;
-  }
+  if (_schemeRegExp.hasMatch(trimmed)) return trimmed;
   return 'http://$trimmed';
+}
+
+List<String> serverUrlCandidates(String url) {
+  final trimmed = url.trim();
+  if (trimmed.isEmpty) return const [];
+  if (_schemeRegExp.hasMatch(trimmed)) return [trimmed];
+  return ['http://$trimmed', 'https://$trimmed'];
+}
+
+class ServerProbeResult {
+  const ServerProbeResult({required this.serverUrl, required this.info});
+
+  final String serverUrl;
+  final PublicSystemInfoDTO info;
 }
 
 class ServerProbeService {
@@ -23,6 +37,16 @@ class ServerProbeService {
           );
 
   final Dio _client;
+
+  Future<ServerProbeResult?> discover(String url) async {
+    for (final candidate in serverUrlCandidates(url)) {
+      final info = await probe(candidate);
+      if (info != null) {
+        return ServerProbeResult(serverUrl: candidate, info: info);
+      }
+    }
+    return null;
+  }
 
   Future<PublicSystemInfoDTO?> probe(String serverUrl) async {
     try {

--- a/lib/src/presentation/pages/library_page.dart
+++ b/lib/src/presentation/pages/library_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -23,9 +25,19 @@ class _LibraryPageState extends ConsumerState<LibraryPage> {
 
   late DeviceType _device;
 
+  bool _autoSelected = false;
+
   Future<void> _onLibraryTap(ItemDTO lib) async {
     await ref.read(currentLibraryProvider.notifier).setLibrary(lib);
     if (mounted) context.goNamed(Routes.listen.name);
+  }
+
+  void _autoSelectSingleLibrary(ItemDTO lib) {
+    if (_autoSelected) return;
+    _autoSelected = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) unawaited(_onLibraryTap(lib));
+    });
   }
 
   @override
@@ -52,69 +64,79 @@ class _LibraryPageState extends ConsumerState<LibraryPage> {
     final data = ref.watch(librariesProvider);
 
     return data.when(
-      data: (libraries) => KeyboardListener(
-        onKeyEvent: (value) {
-          if (value.logicalKey == LogicalKeyboardKey.enter) {
-            _onLibraryTap(libraries[0]);
-          }
-        },
-        focusNode: _focusNode,
-        child: ScrollablePageScaffold(
-          navigationBar: PreferredSize(
-            preferredSize: Size.fromHeight(_device.isMobile ? 48 : 100),
-            child: Padding(
-              padding: EdgeInsets.symmetric(
-                horizontal: _device.isMobile ? 16 : 30,
-              ),
-              child: Row(
-                children: [
-                  CircleAvatar(radius: _device.isDesktop ? 22.5 : 13),
-                  const SizedBox(width: 10),
-                  _titleText(),
-                  const Spacer(),
-                  _searchButton(),
-                  TextButton(
-                    onPressed: ref.read(authProvider.notifier).logout,
-                    child: const Text('Logout'),
-                  ),
-                ],
-              ),
-            ),
-          ),
-          contentPadding: EdgeInsets.only(
-            left: _device.isMobile ? 16 : 30,
-            right: _device.isMobile ? 16 : 30,
-            bottom: _device.isMobile ? 8 : 20,
-          ),
-          slivers: [
-            SliverPadding(
-              padding: EdgeInsets.symmetric(
-                horizontal: _device.isMobile ? 16 : 30,
-              ),
-              sliver: SliverGrid.builder(
-                gridDelegate: (_device.isDesktop || _device.isTablet)
-                    ? SliverGridDelegateWithMaxCrossAxisExtent(
-                        maxCrossAxisExtent: _device.isTablet ? 370 : 358,
-                        mainAxisSpacing: _device.isMobile ? 13 : 34,
-                        crossAxisSpacing: _device.isDesktop
-                            ? 24
-                            : (_device.isMobile ? 16 : 34),
-                        childAspectRatio: 370 / 255,
-                      )
-                    : const SliverGridDelegateWithFixedCrossAxisCount(
-                        crossAxisCount: 1,
-                        mainAxisExtent: 250,
-                      ),
-                itemBuilder: (context, index) => LibraryView(
-                  library: libraries[index],
-                  onTap: () => _onLibraryTap(libraries[index]),
+      data: (libraries) {
+        if (libraries.length == 1) {
+          _autoSelectSingleLibrary(libraries.first);
+          return _loadingScaffold();
+        }
+        return KeyboardListener(
+          onKeyEvent: (value) {
+            if (value.logicalKey == LogicalKeyboardKey.enter &&
+                libraries.isNotEmpty) {
+              _onLibraryTap(libraries.first);
+            }
+          },
+          focusNode: _focusNode,
+          child: ScrollablePageScaffold(
+            navigationBar: PreferredSize(
+              preferredSize: Size.fromHeight(_device.isMobile ? 48 : 100),
+              child: Padding(
+                padding: EdgeInsets.symmetric(
+                  horizontal: _device.isMobile ? 16 : 30,
                 ),
-                itemCount: libraries.length,
+                child: Row(
+                  children: [
+                    CircleAvatar(radius: _device.isDesktop ? 22.5 : 13),
+                    const SizedBox(width: 10),
+                    _titleText(),
+                    const Spacer(),
+                    _searchButton(),
+                    TextButton(
+                      onPressed: ref.read(authProvider.notifier).logout,
+                      child: const Text('Logout'),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ],
-        ),
-      ),
+            contentPadding: EdgeInsets.only(
+              left: _device.isMobile ? 16 : 30,
+              right: _device.isMobile ? 16 : 30,
+              bottom: _device.isMobile ? 8 : 20,
+            ),
+            slivers: [
+              if (libraries.isEmpty)
+                _noLibrariesMessage()
+              else
+                SliverPadding(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: _device.isMobile ? 16 : 30,
+                  ),
+                  sliver: SliverGrid.builder(
+                    gridDelegate: (_device.isDesktop || _device.isTablet)
+                        ? SliverGridDelegateWithMaxCrossAxisExtent(
+                            maxCrossAxisExtent: _device.isTablet ? 370 : 358,
+                            mainAxisSpacing: _device.isMobile ? 13 : 34,
+                            crossAxisSpacing: _device.isDesktop
+                                ? 24
+                                : (_device.isMobile ? 16 : 34),
+                            childAspectRatio: 370 / 255,
+                          )
+                        : const SliverGridDelegateWithFixedCrossAxisCount(
+                            crossAxisCount: 1,
+                            mainAxisExtent: 250,
+                          ),
+                    itemBuilder: (context, index) => LibraryView(
+                      library: libraries[index],
+                      onTap: () => _onLibraryTap(libraries[index]),
+                    ),
+                    itemCount: libraries.length,
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
       error: (_, _) => Scaffold(
         body: Center(
           child: OfflineNotice(
@@ -126,11 +148,7 @@ class _LibraryPageState extends ConsumerState<LibraryPage> {
           ),
         ),
       ),
-      loading: () => const Scaffold(
-        body: Center(
-          child: CircularProgressIndicator.adaptive(),
-        ),
-      ),
+      loading: _loadingScaffold,
     );
   }
 
@@ -139,6 +157,26 @@ class _LibraryPageState extends ConsumerState<LibraryPage> {
     _focusNode.dispose();
     super.dispose();
   }
+
+  Widget _noLibrariesMessage() => const SliverFillRemaining(
+    hasScrollBody: false,
+    child: Center(
+      child: Text(
+        'No libraries found :(',
+        textAlign: TextAlign.center,
+        style: TextStyle(
+          fontSize: 18,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+    ),
+  );
+
+  Widget _loadingScaffold() => const Scaffold(
+    body: Center(
+      child: CircularProgressIndicator.adaptive(),
+    ),
+  );
 
   Widget _titleText() => const Text(
     'Select Library',

--- a/lib/src/presentation/pages/login_page.dart
+++ b/lib/src/presentation/pages/login_page.dart
@@ -1,10 +1,17 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:jplayer/resources/resources.dart';
+import 'package:jplayer/src/data/dto/dto.dart';
 import 'package:jplayer/src/data/params/params.dart';
+import 'package:jplayer/src/data/providers/providers.dart';
+import 'package:jplayer/src/data/services/server_probe_service.dart';
 import 'package:jplayer/src/presentation/widgets/widgets.dart';
 import 'package:jplayer/src/providers/auth_provider.dart';
+
+const _discoveredColor = Color(0xFF34C759);
 
 class LoginPage extends ConsumerStatefulWidget {
   const LoginPage({super.key});
@@ -18,12 +25,79 @@ class LoginPageState extends ConsumerState<LoginPage> {
   final _serverUrlInputController = TextEditingController();
   final _emailInputController = TextEditingController();
   final _passwordInputController = TextEditingController();
+  final _serverUrlFocusNode = FocusNode();
+
+  PublicSystemInfoDTO? _discoveredServer;
+  String? _probedUrl;
+  int _probeGeneration = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _serverUrlFocusNode.addListener(_onServerUrlFocusChange);
+    _serverUrlInputController.addListener(_onServerUrlChanged);
+  }
+
+  @override
+  void dispose() {
+    _serverUrlFocusNode
+      ..removeListener(_onServerUrlFocusChange)
+      ..dispose();
+    _serverUrlInputController
+      ..removeListener(_onServerUrlChanged)
+      ..dispose();
+    _emailInputController.dispose();
+    _passwordInputController.dispose();
+    super.dispose();
+  }
+
+  void _onServerUrlFocusChange() {
+    if (!_serverUrlFocusNode.hasFocus) unawaited(_probeServer());
+  }
+
+  void _onServerUrlChanged() {
+    if (_probedUrl == null) return;
+    if (normalizeServerUrl(_serverUrlInputController.text) == _probedUrl) return;
+    _resetDiscoveredServer();
+  }
+
+  Future<void> _probeServer() async {
+    final rawUrl = _serverUrlInputController.text.trim();
+    if (rawUrl.isEmpty) {
+      _resetDiscoveredServer();
+      return;
+    }
+
+    final serverUrl = normalizeServerUrl(rawUrl);
+    if (serverUrl == _probedUrl) return;
+
+    final generation = ++_probeGeneration;
+    _probedUrl = serverUrl;
+    if (_discoveredServer != null) {
+      setState(() => _discoveredServer = null);
+    }
+
+    final info = await ref.read(serverProbeServiceProvider).probe(serverUrl);
+    if (!mounted || generation != _probeGeneration) return;
+
+    setState(() => _discoveredServer = info);
+  }
+
+  void _resetDiscoveredServer() {
+    _probeGeneration++;
+    _probedUrl = null;
+    if (_discoveredServer == null) return;
+    setState(() => _discoveredServer = null);
+  }
 
   Future<void> signIn() async {
+    if (error != null) setState(() => error = null);
+
+    final rawServerUrl = _serverUrlInputController.text.trim();
     final credentials = UserCredentials(
       username: _emailInputController.text.trim(),
       pw: _passwordInputController.text.trim(),
-      serverUrl: _serverUrlInputController.text.trim(),
+      serverUrl: rawServerUrl.isEmpty ? '' : normalizeServerUrl(rawServerUrl),
     );
     if (credentials.serverUrl.isEmpty || credentials.username.isEmpty) {
       setState(() {
@@ -40,7 +114,7 @@ class LoginPageState extends ConsumerState<LoginPage> {
       return;
     }
     final resp = await ref.read(authProvider.notifier).login(credentials);
-    if (resp != null) {
+    if (resp != null && mounted) {
       setState(() {
         error = resp;
       });
@@ -83,8 +157,8 @@ class LoginPageState extends ConsumerState<LoginPage> {
                             const SizedBox(height: 8),
                             _passwordField(),
                             if (error != null) ...[
-                              const SizedBox(height: 8),
-                              Text(error!),
+                              const SizedBox(height: 12),
+                              _errorText(error!),
                             ],
                             const SizedBox(height: 63),
                             _signInButton(),
@@ -100,11 +174,47 @@ class LoginPageState extends ConsumerState<LoginPage> {
     );
   }
 
-  Widget _serverURLField() => LabeledTextField(
-    label: 'Server URL',
-    keyboardType: TextInputType.url,
-    controller: _serverUrlInputController,
-    textInputAction: TextInputAction.next,
+  Widget _errorText(String message) => Text(
+    message,
+    textAlign: TextAlign.center,
+    style: TextStyle(
+      fontFamily: FontFamily.inter,
+      fontSize: 14,
+      fontWeight: FontWeight.w500,
+      color: Theme.of(context).colorScheme.error,
+    ),
+  );
+
+  Widget _serverURLField() => Column(
+    mainAxisSize: MainAxisSize.min,
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      LabeledTextField(
+        label: 'Server URL',
+        keyboardType: TextInputType.url,
+        controller: _serverUrlInputController,
+        focusNode: _serverUrlFocusNode,
+        textInputAction: TextInputAction.next,
+        suffixIcon: _serverUrlSuffixIcon(),
+      ),
+      if (_discoveredServer != null) _discoveredServerText(_discoveredServer!),
+    ],
+  );
+
+  Widget? _serverUrlSuffixIcon() => (_discoveredServer != null)
+      ? const Icon(Icons.check_circle, color: _discoveredColor, size: 22)
+      : null;
+
+  Widget _discoveredServerText(PublicSystemInfoDTO server) => Padding(
+    padding: const EdgeInsets.only(top: 4),
+    child: Text(
+      'Discovered: ${server.serverName ?? 'Jellyfin server'}',
+      style: const TextStyle(
+        fontFamily: FontFamily.inter,
+        fontSize: 12,
+        color: _discoveredColor,
+      ),
+    ),
   );
 
   Widget _loginField() => LabeledTextField(

--- a/lib/src/presentation/pages/login_page.dart
+++ b/lib/src/presentation/pages/login_page.dart
@@ -4,14 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:jplayer/resources/resources.dart';
-import 'package:jplayer/src/data/dto/dto.dart';
 import 'package:jplayer/src/data/params/params.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
 import 'package:jplayer/src/data/services/server_probe_service.dart';
 import 'package:jplayer/src/presentation/widgets/widgets.dart';
 import 'package:jplayer/src/providers/auth_provider.dart';
-
-const _discoveredColor = Color(0xFF34C759);
 
 class LoginPage extends ConsumerStatefulWidget {
   const LoginPage({super.key});
@@ -27,8 +24,8 @@ class LoginPageState extends ConsumerState<LoginPage> {
   final _passwordInputController = TextEditingController();
   final _serverUrlFocusNode = FocusNode();
 
-  PublicSystemInfoDTO? _discoveredServer;
-  String? _probedUrl;
+  ServerProbeResult? _discoveredServer;
+  String? _probedInput;
   int _probeGeneration = 0;
 
   @override
@@ -56,8 +53,8 @@ class LoginPageState extends ConsumerState<LoginPage> {
   }
 
   void _onServerUrlChanged() {
-    if (_probedUrl == null) return;
-    if (normalizeServerUrl(_serverUrlInputController.text) == _probedUrl) return;
+    if (_probedInput == null) return;
+    if (_serverUrlInputController.text.trim() == _probedInput) return;
     _resetDiscoveredServer();
   }
 
@@ -67,25 +64,23 @@ class LoginPageState extends ConsumerState<LoginPage> {
       _resetDiscoveredServer();
       return;
     }
-
-    final serverUrl = normalizeServerUrl(rawUrl);
-    if (serverUrl == _probedUrl) return;
+    if (rawUrl == _probedInput) return;
 
     final generation = ++_probeGeneration;
-    _probedUrl = serverUrl;
+    _probedInput = rawUrl;
     if (_discoveredServer != null) {
       setState(() => _discoveredServer = null);
     }
 
-    final info = await ref.read(serverProbeServiceProvider).probe(serverUrl);
+    final result = await ref.read(serverProbeServiceProvider).discover(rawUrl);
     if (!mounted || generation != _probeGeneration) return;
 
-    setState(() => _discoveredServer = info);
+    setState(() => _discoveredServer = result);
   }
 
   void _resetDiscoveredServer() {
     _probeGeneration++;
-    _probedUrl = null;
+    _probedInput = null;
     if (_discoveredServer == null) return;
     setState(() => _discoveredServer = null);
   }
@@ -97,7 +92,9 @@ class LoginPageState extends ConsumerState<LoginPage> {
     final credentials = UserCredentials(
       username: _emailInputController.text.trim(),
       pw: _passwordInputController.text.trim(),
-      serverUrl: rawServerUrl.isEmpty ? '' : normalizeServerUrl(rawServerUrl),
+      serverUrl: rawServerUrl.isEmpty
+          ? ''
+          : _discoveredServer?.serverUrl ?? normalizeServerUrl(rawServerUrl),
     );
     if (credentials.serverUrl.isEmpty || credentials.username.isEmpty) {
       setState(() {
@@ -106,10 +103,12 @@ class LoginPageState extends ConsumerState<LoginPage> {
       return;
     }
 
-    if (!Uri.parse(credentials.serverUrl).isAbsolute) {
+    final serverUri = Uri.tryParse(credentials.serverUrl);
+    if (serverUri == null || !serverUri.isAbsolute || serverUri.host.isEmpty) {
       setState(() {
         error =
-            'Server URL is invalid. Should start with http/https and does not contain any path or query parameters';
+            'Server URL is invalid. Try something like 192.168.1.10:8096 or '
+            'jellyfin.example.com';
       });
       return;
     }
@@ -128,46 +127,44 @@ class LoginPageState extends ConsumerState<LoginPage> {
         minimum: const EdgeInsets.symmetric(vertical: 36, horizontal: 48),
         child: Center(
           child: LayoutBuilder(
-            builder:
-                (context, constraints) => SingleChildScrollView(
-                  keyboardDismissBehavior:
-                      ScrollViewKeyboardDismissBehavior.onDrag,
-                  child: ConstrainedBox(
-                    constraints: BoxConstraints(
-                      minHeight: constraints.maxHeight,
-                      maxWidth: 440,
-                    ),
-                    child: IntrinsicHeight(
-                      child: KeyboardListener(
-                        focusNode: FocusNode(),
-                        onKeyEvent: (event) {
-                          if (event.logicalKey == LogicalKeyboardKey.enter) {
-                            signIn();
-                          }
-                        },
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Image.asset(Images.mainLogo),
-                            const SizedBox(height: 63),
-                            _serverURLField(),
-                            const SizedBox(height: 8),
-                            _loginField(),
-                            const SizedBox(height: 8),
-                            _passwordField(),
-                            if (error != null) ...[
-                              const SizedBox(height: 12),
-                              _errorText(error!),
-                            ],
-                            const SizedBox(height: 63),
-                            _signInButton(),
-                          ],
-                        ),
-                      ),
+            builder: (context, constraints) => SingleChildScrollView(
+              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  minHeight: constraints.maxHeight,
+                  maxWidth: 440,
+                ),
+                child: IntrinsicHeight(
+                  child: KeyboardListener(
+                    focusNode: FocusNode(),
+                    onKeyEvent: (event) {
+                      if (event.logicalKey == LogicalKeyboardKey.enter) {
+                        signIn();
+                      }
+                    },
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Image.asset(Images.mainLogo),
+                        const SizedBox(height: 63),
+                        _serverURLField(),
+                        const SizedBox(height: 8),
+                        _loginField(),
+                        const SizedBox(height: 8),
+                        _passwordField(),
+                        if (error != null) ...[
+                          const SizedBox(height: 12),
+                          _errorText(error!),
+                        ],
+                        const SizedBox(height: 63),
+                        _signInButton(),
+                      ],
                     ),
                   ),
                 ),
+              ),
+            ),
           ),
         ),
       ),
@@ -202,17 +199,21 @@ class LoginPageState extends ConsumerState<LoginPage> {
   );
 
   Widget? _serverUrlSuffixIcon() => (_discoveredServer != null)
-      ? const Icon(Icons.check_circle, color: _discoveredColor, size: 22)
+      ? Icon(
+          Icons.check_circle,
+          color: Theme.of(context).colorScheme.secondary,
+          size: 22,
+        )
       : null;
 
-  Widget _discoveredServerText(PublicSystemInfoDTO server) => Padding(
+  Widget _discoveredServerText(ServerProbeResult server) => Padding(
     padding: const EdgeInsets.only(top: 4),
     child: Text(
-      'Discovered: ${server.serverName ?? 'Jellyfin server'}',
-      style: const TextStyle(
+      'Discovered: ${server.info.serverName ?? 'Jellyfin server'}',
+      style: TextStyle(
         fontFamily: FontFamily.inter,
         fontSize: 12,
-        color: _discoveredColor,
+        color: Theme.of(context).colorScheme.secondary,
       ),
     ),
   );

--- a/lib/src/presentation/widgets/labeled_text_field.dart
+++ b/lib/src/presentation/widgets/labeled_text_field.dart
@@ -10,6 +10,8 @@ class LabeledTextField extends StatelessWidget {
     this.obscureText = false,
     this.textInputAction,
     this.autofocus = false,
+    this.focusNode,
+    this.suffixIcon,
     super.key,
   });
 
@@ -20,6 +22,8 @@ class LabeledTextField extends StatelessWidget {
   final TextInputType? keyboardType;
   final TextInputAction? textInputAction;
   final bool autofocus;
+  final FocusNode? focusNode;
+  final Widget? suffixIcon;
 
   @override
   Widget build(BuildContext context) {
@@ -46,6 +50,7 @@ class LabeledTextField extends StatelessWidget {
 
   Widget _textField() => TextField(
         controller: controller,
+        focusNode: focusNode,
         keyboardType: keyboardType,
         textInputAction: textInputAction,
         obscureText: obscureText,
@@ -57,6 +62,10 @@ class LabeledTextField extends StatelessWidget {
             borderSide: BorderSide.none,
             borderRadius: BorderRadius.circular(10),
           ),
+          suffixIcon: suffixIcon,
+          suffixIconConstraints: (suffixIcon != null)
+              ? const BoxConstraints(minWidth: 44)
+              : null,
           contentPadding: const EdgeInsets.symmetric(horizontal: 12),
           hintText: placeholder,
           hintStyle: const TextStyle(

--- a/lib/src/providers/auth_provider.dart
+++ b/lib/src/providers/auth_provider.dart
@@ -8,6 +8,8 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:jplayer/src/data/api/api.dart';
 import 'package:jplayer/src/data/params/params.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
+import 'package:jplayer/src/data/services/server_probe_service.dart';
+import 'package:jplayer/src/domain/providers/current_library_provider.dart';
 import 'package:jplayer/src/domain/providers/current_user_provider.dart';
 import 'package:jplayer/src/providers/base_url_provider.dart';
 
@@ -16,7 +18,8 @@ class AuthNotifier extends AsyncNotifier<bool?> {
     _noAuthNetworkInterceptor = InterceptorsWrapper(
       onError: (error, handler) {
         final statusCode = error.response?.statusCode;
-        if (statusCode == 401) logout();
+        if (statusCode == 401 && !_authenticating && !_loggingOut) logout();
+        handler.next(error);
       },
     );
   }
@@ -25,6 +28,13 @@ class AuthNotifier extends AsyncNotifier<bool?> {
   late Dio _client;
   late FlutterSecureStorage _storage;
   late JellyfinApi _api;
+
+  bool _authenticating = false;
+  bool _loggingOut = false;
+
+  static const serverUnreachableError =
+      'Server is not accessible. Check the server URL and your connection.';
+  static const invalidCredentialsError = 'Incorrect login or password';
 
   static const _serverUrlKey = 'serverUrl';
   static const _userIdKey = 'userId';
@@ -65,8 +75,9 @@ class AuthNotifier extends AsyncNotifier<bool?> {
 
   Future<String?> login(UserCredentials credentials) async {
     // state = const AsyncLoading<bool>();
-    final serverUrl = _normalizeUrl(credentials.serverUrl);
+    final serverUrl = normalizeServerUrl(credentials.serverUrl);
     _api = JellyfinApi(_client, baseUrl: serverUrl);
+    _authenticating = true;
     try {
       final response = await _api.signIn(credentials: credentials);
       print(response.data.sessionInfo); // TODO: remove after testing
@@ -85,29 +96,58 @@ class AuthNotifier extends AsyncNotifier<bool?> {
       if (tokenValidated) _setAuthHeader(token);
       state = AsyncData(tokenValidated);
     } on DioException catch (e) {
-      return e.error?.toString();
+      return _loginErrorMessage(e);
       // state = AsyncError<bool>(e.error!, e.stackTrace);
+    } finally {
+      _authenticating = false;
     }
     return state.error?.toString();
   }
 
+  String _loginErrorMessage(DioException e) {
+    switch (e.type) {
+      case DioExceptionType.badResponse:
+        final statusCode = e.response?.statusCode;
+        if (statusCode == 401 || statusCode == 403) {
+          return invalidCredentialsError;
+        }
+        return serverUnreachableError;
+
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
+      case DioExceptionType.connectionError:
+      case DioExceptionType.badCertificate:
+      case DioExceptionType.cancel:
+      case DioExceptionType.unknown:
+        return serverUnreachableError;
+    }
+  }
+
   Future<void> logout() async {
+    if (_loggingOut) return;
+    _loggingOut = true;
     state = const AsyncLoading();
     try {
       await Future.wait([
         ref.read(sharedPreferencesProvider).requireValue.clear(),
         _storage.deleteAll(),
-        _api.signOut(),
+        _signOutQuietly(),
       ]);
     } finally {
+      ref.invalidate(currentLibraryProvider);
       _removeAuthHeader();
       state = const AsyncData(false);
+      _loggingOut = false;
     }
   }
 
-  String _normalizeUrl(String url) {
-    if (RegExp('^https?').hasMatch(url)) return url;
-    return 'http://$url';
+  Future<void> _signOutQuietly() async {
+    try {
+      await _api.signOut();
+    } on Object {
+      return;
+    }
   }
 
   bool _validateAuthToken(String? token, String userId) {

--- a/test/data/services/server_probe_service_test.dart
+++ b/test/data/services/server_probe_service_test.dart
@@ -65,6 +65,81 @@ void main() {
     });
   });
 
+  group('serverUrlCandidates', () {
+    test('- tries http then https when no scheme is given', () {
+      expect(serverUrlCandidates('jelly.local:8096'), [
+        'http://jelly.local:8096',
+        'https://jelly.local:8096',
+      ]);
+    });
+
+    test('- only tries what the user typed when a scheme is given', () {
+      expect(serverUrlCandidates('https://jelly.local'), [
+        'https://jelly.local',
+      ]);
+    });
+
+    test('- has no candidates for empty input', () {
+      expect(serverUrlCandidates('   '), isEmpty);
+    });
+  });
+
+  group('ServerProbeService.discover', () {
+    test('- resolves a scheme-less url over http when http answers', () async {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenAnswer(
+        respondWith(jsonBody({'Id': 'a', 'Version': '10.9.11'}, 200)),
+      );
+
+      final result = await service.discover('jelly.local:8096');
+
+      expect(result, isNotNull);
+      expect(result!.serverUrl, 'http://jelly.local:8096');
+    });
+
+    test('- falls back to https when http does not answer', () async {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenAnswer((
+        invocation,
+      ) async {
+        final options = invocation.positionalArguments.first as RequestOptions;
+        if (options.uri.scheme == 'http') {
+          throw DioException.connectionError(
+            requestOptions: options,
+            reason: 'refused',
+          );
+        }
+        return jsonBody({'Id': 'a', 'Version': '10.9.11'}, 200);
+      });
+
+      final result = await service.discover('jelly.example.com');
+
+      expect(result, isNotNull);
+      expect(result!.serverUrl, 'https://jelly.example.com');
+    });
+
+    test('- returns null when neither scheme answers', () async {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenThrow(
+        DioException.connectionError(
+          requestOptions: RequestOptions(path: '/System/Info/Public'),
+          reason: 'refused',
+        ),
+      );
+
+      expect(await service.discover('jelly.local'), isNull);
+    });
+
+    test('- does not guess a scheme the user already gave', () async {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenThrow(
+        DioException.connectionError(
+          requestOptions: RequestOptions(path: '/System/Info/Public'),
+          reason: 'refused',
+        ),
+      );
+
+      expect(await service.discover('https://jelly.local'), isNull);
+      verify(() => mockAdapter.fetch(any(), any(), any())).called(1);
+    });
+  });
+
   group('ServerProbeService', () {
     test(
       '- returns the server info when the server is a Jellyfin server',

--- a/test/data/services/server_probe_service_test.dart
+++ b/test/data/services/server_probe_service_test.dart
@@ -1,0 +1,159 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/data/services/server_probe_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockHttpClientAdapter extends Mock implements HttpClientAdapter {}
+
+void main() {
+  late MockHttpClientAdapter mockAdapter;
+  late ServerProbeService service;
+
+  ResponseBody jsonBody(Object? body, int statusCode) =>
+      ResponseBody.fromString(
+        jsonEncode(body),
+        statusCode,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      );
+
+  Future<ResponseBody> Function(Invocation) respondWith(ResponseBody body) =>
+      (_) async => body;
+
+  setUpAll(() {
+    registerFallbackValue(RequestOptions(path: '/'));
+    registerFallbackValue(const Stream<Uint8List>.empty());
+  });
+
+  setUp(() {
+    mockAdapter = MockHttpClientAdapter();
+    service = ServerProbeService(
+      client: Dio()..httpClientAdapter = mockAdapter,
+    );
+  });
+
+  group('normalizeServerUrl', () {
+    test('- prefixes http when no scheme is given', () {
+      expect(normalizeServerUrl('jelly.local:8096'), 'http://jelly.local:8096');
+    });
+
+    test('- keeps an existing http scheme', () {
+      expect(normalizeServerUrl('http://jelly.local'), 'http://jelly.local');
+    });
+
+    test('- keeps an existing https scheme', () {
+      expect(normalizeServerUrl('https://jelly.local'), 'https://jelly.local');
+    });
+
+    test('- is case insensitive about the scheme', () {
+      expect(normalizeServerUrl('HTTPS://jelly.local'), 'HTTPS://jelly.local');
+    });
+
+    test('- trims surrounding whitespace', () {
+      expect(
+        normalizeServerUrl('  http://jelly.local  '),
+        'http://jelly.local',
+      );
+    });
+
+    test('- does not treat a host starting with http as a scheme', () {
+      expect(normalizeServerUrl('httpserver.local'), 'http://httpserver.local');
+    });
+  });
+
+  group('ServerProbeService', () {
+    test(
+      '- returns the server info when the server is a Jellyfin server',
+      () async {
+        when(() => mockAdapter.fetch(any(), any(), any())).thenAnswer(
+          respondWith(
+            jsonBody({
+              'Id': 'server-id',
+              'ServerName': 'Living Room',
+              'Version': '10.9.11',
+              'ProductName': 'Jellyfin Server',
+            }, 200),
+          ),
+        );
+
+        final info = await service.probe('http://jelly.local');
+
+        expect(info, isNotNull);
+        expect(info!.serverName, 'Living Room');
+        expect(info.version, '10.9.11');
+      },
+    );
+
+    test('- requests the public system info endpoint', () async {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenAnswer(
+        respondWith(jsonBody({'Id': 'a', 'Version': '10.9.11'}, 200)),
+      );
+
+      await service.probe('http://jelly.local');
+
+      final captured =
+          verify(
+                () => mockAdapter.fetch(captureAny(), any(), any()),
+              ).captured.single
+              as RequestOptions;
+      expect(captured.uri.toString(), 'http://jelly.local/System/Info/Public');
+      expect(captured.method, 'GET');
+    });
+
+    test('- returns null when the payload is not a Jellyfin server', () async {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenAnswer(
+        respondWith(jsonBody({'hello': 'world'}, 200)),
+      );
+
+      expect(await service.probe('http://jelly.local'), isNull);
+    });
+
+    test('- returns null when the response is not json', () async {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenAnswer(
+        (_) async => ResponseBody.fromString(
+          '<html><body>hello</body></html>',
+          200,
+          headers: {
+            Headers.contentTypeHeader: ['text/html'],
+          },
+        ),
+      );
+
+      expect(await service.probe('http://jelly.local'), isNull);
+    });
+
+    test('- returns null when the server responds with an error', () async {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenAnswer(
+        respondWith(jsonBody({'error': 'nope'}, 500)),
+      );
+
+      expect(await service.probe('http://jelly.local'), isNull);
+    });
+
+    test('- returns null when the server cannot be reached', () async {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenThrow(
+        DioException.connectionError(
+          requestOptions: RequestOptions(path: '/System/Info/Public'),
+          reason: 'no route to host',
+        ),
+      );
+
+      expect(await service.probe('http://unreachable.local'), isNull);
+    });
+
+    test('- returns null when the request times out', () async {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenThrow(
+        DioException.connectionTimeout(
+          timeout: const Duration(seconds: 6),
+          requestOptions: RequestOptions(path: '/System/Info/Public'),
+        ),
+      );
+
+      expect(await service.probe('http://unreachable.local'), isNull);
+    });
+  });
+}

--- a/test/presentation/pages/library_page_test.dart
+++ b/test/presentation/pages/library_page_test.dart
@@ -2,10 +2,14 @@ import 'package:faker_dart/faker_dart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:jplayer/main.dart';
+import 'package:jplayer/src/config/routes.dart';
 import 'package:jplayer/src/data/dto/dto.dart';
+import 'package:jplayer/src/domain/providers/current_library_provider.dart';
 import 'package:jplayer/src/domain/providers/libraries_provider.dart';
 import 'package:jplayer/src/presentation/pages/library_page.dart';
+import 'package:jplayer/src/presentation/themes/themes.dart';
 import 'package:jplayer/src/presentation/widgets/widgets.dart';
 import 'package:jplayer/src/providers/auth_provider.dart';
 import 'package:mocktail/mocktail.dart';
@@ -21,14 +25,22 @@ class MockAuthNotifier extends AsyncNotifier<bool?>
     with Mock
     implements AuthNotifier {}
 
+class MockCurrentLibraryNotifier extends AutoDisposeAsyncNotifier<ItemDTO?>
+    with Mock
+    implements CurrentLibraryNotifier {}
+
+class FakeItemDTO extends Fake implements ItemDTO {}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late LibrariesNotifier mockLibrariesNotifier;
   late AuthNotifier mockAuthNotifier;
+  late CurrentLibraryNotifier mockCurrentLibraryNotifier;
 
   final faker = Faker.instance;
-  final mockLibrary = ItemDTO(
+
+  ItemDTO buildLibrary() => ItemDTO(
     id: faker.datatype.uuid(),
     name: faker.lorem.sentence(),
     path: faker.internet.url(),
@@ -36,26 +48,57 @@ void main() {
     collectionType: 'music',
   );
 
+  final mockLibraries = [buildLibrary(), buildLibrary()];
+
+  List<Override> overrides() => [
+    librariesProvider.overrideWith(() => mockLibrariesNotifier),
+    authProvider.overrideWith(() => mockAuthNotifier),
+    currentLibraryProvider.overrideWith(() => mockCurrentLibraryNotifier),
+  ];
+
   Widget getWidgetUT() => createTestApp(
-    providerContainer: createProviderContainer(
-      overrides: [
-        librariesProvider.overrideWith(() => mockLibrariesNotifier),
-        authProvider.overrideWith(() => mockAuthNotifier),
-      ],
-    ),
+    providerContainer: createProviderContainer(overrides: overrides()),
     home: const LibraryPage(),
+  );
+
+  Widget getRoutedWidgetUT() => UncontrolledProviderScope(
+    container: createProviderContainer(overrides: overrides()),
+    child: MaterialApp.router(
+      debugShowCheckedModeBanner: false,
+      theme: Themes.red,
+      routerConfig: GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => const LibraryPage(),
+          ),
+          GoRoute(
+            path: Routes.listen.path,
+            name: Routes.listen.name,
+            builder: (context, state) =>
+                const Scaffold(body: Text('listen page')),
+          ),
+        ],
+      ),
+    ),
   );
 
   setUpAll(() {
     deviceId = faker.datatype.uuid();
+    registerFallbackValue(FakeItemDTO());
   });
 
   setUp(() {
     mockLibrariesNotifier = MockLibrariesNotifier();
     mockAuthNotifier = MockAuthNotifier();
-    when(mockLibrariesNotifier.build).thenAnswer((_) async => [mockLibrary]);
+    mockCurrentLibraryNotifier = MockCurrentLibraryNotifier();
+    when(mockLibrariesNotifier.build).thenAnswer((_) async => mockLibraries);
     when(mockAuthNotifier.build).thenAnswer((_) async => true);
     when(() => mockAuthNotifier.logout()).thenAnswer((_) async {});
+    when(mockCurrentLibraryNotifier.build).thenAnswer((_) async => null);
+    when(
+      () => mockCurrentLibraryNotifier.setLibrary(any()),
+    ).thenAnswer((_) async {});
   });
 
   group('LibraryPage', () {
@@ -65,14 +108,16 @@ void main() {
         await widgetTester.pumpWidget(getWidgetUT());
         await widgetTester.pump(Duration.zero);
         final libraryFinder = find.byType(LibraryView);
-        expect(libraryFinder, findsOneWidget);
-        expect(
-          find.descendant(
-            of: libraryFinder,
-            matching: find.text(mockLibrary.name),
-          ),
-          findsOneWidget,
-        );
+        expect(libraryFinder, findsNWidgets(mockLibraries.length));
+        for (final library in mockLibraries) {
+          expect(
+            find.descendant(
+              of: libraryFinder,
+              matching: find.text(library.name),
+            ),
+            findsOneWidget,
+          );
+        }
       },
     );
 
@@ -86,6 +131,54 @@ void main() {
         await widgetTester.tap(buttonFinder);
         await widgetTester.pumpAndSettle();
         verify(mockAuthNotifier.logout).called(1);
+      },
+    );
+
+    testWidgets(
+      '- auto selects the library when there is only one',
+      (widgetTester) async {
+        final onlyLibrary = buildLibrary();
+        when(mockLibrariesNotifier.build).thenAnswer(
+          (_) async => [
+            onlyLibrary,
+          ],
+        );
+
+        await widgetTester.pumpWidget(getRoutedWidgetUT());
+        await widgetTester.pumpAndSettle();
+
+        verify(
+          () => mockCurrentLibraryNotifier.setLibrary(onlyLibrary),
+        ).called(1);
+        expect(find.byType(LibraryView), findsNothing);
+        expect(find.text('Select Library'), findsNothing);
+        expect(find.text('listen page'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      '- keeps the picker when there is more than one library',
+      (widgetTester) async {
+        await widgetTester.pumpWidget(getRoutedWidgetUT());
+        await widgetTester.pumpAndSettle();
+
+        verifyNever(() => mockCurrentLibraryNotifier.setLibrary(any()));
+        expect(find.text('Select Library'), findsOneWidget);
+        expect(find.text('listen page'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      '- shows a message when there are no libraries',
+      (widgetTester) async {
+        when(mockLibrariesNotifier.build).thenAnswer((_) async => []);
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pump(Duration.zero);
+
+        expect(find.text('No libraries found :('), findsOneWidget);
+        expect(find.byType(LibraryView), findsNothing);
+        expect(find.text('Logout'), findsOneWidget);
       },
     );
   });

--- a/test/presentation/pages/login_page_test.dart
+++ b/test/presentation/pages/login_page_test.dart
@@ -40,6 +40,15 @@ void main() {
     home: const LoginPage(),
   );
 
+  ServerProbeResult discoveryResult(String serverUrl) => ServerProbeResult(
+    serverUrl: serverUrl,
+    info: const PublicSystemInfoDTO(
+      id: 'server-id',
+      serverName: 'Living Room',
+      version: '10.9.11',
+    ),
+  );
+
   Future<void> enterServerUrlAndUnfocus(
     WidgetTester widgetTester,
     String url,
@@ -62,7 +71,7 @@ void main() {
     mockProbeService = MockServerProbeService();
     when(mockAuthNotifier.build).thenAnswer((_) async => true);
     when(() => mockAuthNotifier.login(any())).thenAnswer((_) async => null);
-    when(() => mockProbeService.probe(any())).thenAnswer((_) async => null);
+    when(() => mockProbeService.discover(any())).thenAnswer((_) async => null);
   });
 
   group('LoginPage', () {
@@ -124,42 +133,83 @@ void main() {
     testWidgets(
       '- shows the discovered server when the url field loses focus',
       (widgetTester) async {
-        when(() => mockProbeService.probe(any())).thenAnswer(
-          (_) async => const PublicSystemInfoDTO(
-            id: 'server-id',
-            serverName: 'Living Room',
-            version: '10.9.11',
-          ),
+        when(() => mockProbeService.discover(any())).thenAnswer(
+          (_) async => discoveryResult('http://jelly.local'),
         );
 
         await widgetTester.pumpWidget(getWidgetUT());
         await widgetTester.pump(Duration.zero);
         await enterServerUrlAndUnfocus(widgetTester, 'http://jelly.local');
 
-        verify(() => mockProbeService.probe('http://jelly.local')).called(1);
+        verify(() => mockProbeService.discover('http://jelly.local')).called(1);
         expect(find.text('Discovered: Living Room'), findsOneWidget);
         expect(find.byIcon(Icons.check_circle), findsOneWidget);
       },
     );
 
     testWidgets(
-      '- normalizes the url before probing it',
+      '- discovers a server entered without a scheme',
       (widgetTester) async {
-        when(() => mockProbeService.probe(any())).thenAnswer(
-          (_) async => const PublicSystemInfoDTO(
-            id: 'server-id',
-            serverName: 'Living Room',
-            version: '10.9.11',
-          ),
+        when(() => mockProbeService.discover(any())).thenAnswer(
+          (_) async => discoveryResult('http://jelly.local:8096'),
         );
 
         await widgetTester.pumpWidget(getWidgetUT());
         await widgetTester.pump(Duration.zero);
         await enterServerUrlAndUnfocus(widgetTester, 'jelly.local:8096');
 
-        verify(
-          () => mockProbeService.probe('http://jelly.local:8096'),
-        ).called(1);
+        verify(() => mockProbeService.discover('jelly.local:8096')).called(1);
+        expect(find.text('Discovered: Living Room'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      '- signs in with the scheme discovery resolved',
+      (widgetTester) async {
+        when(() => mockProbeService.discover(any())).thenAnswer(
+          (_) async => discoveryResult('https://jelly.example.com'),
+        );
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pump(Duration.zero);
+        await enterServerUrlAndUnfocus(widgetTester, 'jelly.example.com');
+        await widgetTester.enterText(
+          find.widgetWithText(LabeledTextField, 'Login'),
+          'alex',
+        );
+        final signInFinder = find.widgetWithText(ShadowedButton, 'Sign in');
+        await widgetTester.ensureVisible(signInFinder);
+        await widgetTester.pumpAndSettle();
+        await widgetTester.tap(signInFinder);
+        await widgetTester.pumpAndSettle();
+
+        final credentials =
+            verify(() => mockAuthNotifier.login(captureAny())).captured.single
+                as UserCredentials;
+        expect(credentials.serverUrl, 'https://jelly.example.com');
+      },
+    );
+
+    testWidgets(
+      '- falls back to http when discovery finds nothing',
+      (widgetTester) async {
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pump(Duration.zero);
+        await enterServerUrlAndUnfocus(widgetTester, 'jelly.local:8096');
+        await widgetTester.enterText(
+          find.widgetWithText(LabeledTextField, 'Login'),
+          'alex',
+        );
+        final signInFinder = find.widgetWithText(ShadowedButton, 'Sign in');
+        await widgetTester.ensureVisible(signInFinder);
+        await widgetTester.pumpAndSettle();
+        await widgetTester.tap(signInFinder);
+        await widgetTester.pumpAndSettle();
+
+        final credentials =
+            verify(() => mockAuthNotifier.login(captureAny())).captured.single
+                as UserCredentials;
+        expect(credentials.serverUrl, 'http://jelly.local:8096');
       },
     );
 
@@ -170,7 +220,7 @@ void main() {
         await widgetTester.pump(Duration.zero);
         await enterServerUrlAndUnfocus(widgetTester, 'http://nope.local');
 
-        verify(() => mockProbeService.probe('http://nope.local')).called(1);
+        verify(() => mockProbeService.discover('http://nope.local')).called(1);
         expect(find.textContaining('Discovered:'), findsNothing);
         expect(find.byIcon(Icons.check_circle), findsNothing);
       },
@@ -179,12 +229,8 @@ void main() {
     testWidgets(
       '- clears the discovered server when the url is edited',
       (widgetTester) async {
-        when(() => mockProbeService.probe(any())).thenAnswer(
-          (_) async => const PublicSystemInfoDTO(
-            id: 'server-id',
-            serverName: 'Living Room',
-            version: '10.9.11',
-          ),
+        when(() => mockProbeService.discover(any())).thenAnswer(
+          (_) async => discoveryResult('http://jelly.local'),
         );
 
         await widgetTester.pumpWidget(getWidgetUT());

--- a/test/presentation/pages/login_page_test.dart
+++ b/test/presentation/pages/login_page_test.dart
@@ -2,7 +2,10 @@ import 'package:faker_dart/faker_dart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/data/dto/dto.dart';
 import 'package:jplayer/src/data/params/params.dart';
+import 'package:jplayer/src/data/providers/providers.dart';
+import 'package:jplayer/src/data/services/server_probe_service.dart';
 import 'package:jplayer/src/presentation/pages/login_page.dart';
 import 'package:jplayer/src/presentation/widgets/widgets.dart';
 import 'package:jplayer/src/providers/auth_provider.dart';
@@ -15,12 +18,15 @@ class MockAuthNotifier extends AsyncNotifier<bool?>
     with Mock
     implements AuthNotifier {}
 
+class MockServerProbeService extends Mock implements ServerProbeService {}
+
 class FakeUserCredentials extends Fake implements UserCredentials {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late AuthNotifier mockAuthNotifier;
+  late MockServerProbeService mockProbeService;
 
   final faker = Faker.instance;
 
@@ -28,10 +34,24 @@ void main() {
     providerContainer: createProviderContainer(
       overrides: [
         authProvider.overrideWith(() => mockAuthNotifier),
+        serverProbeServiceProvider.overrideWithValue(mockProbeService),
       ],
     ),
     home: const LoginPage(),
   );
+
+  Future<void> enterServerUrlAndUnfocus(
+    WidgetTester widgetTester,
+    String url,
+  ) async {
+    await widgetTester.enterText(
+      find.widgetWithText(LabeledTextField, 'Server URL'),
+      url,
+    );
+    await widgetTester.pump();
+    await widgetTester.tap(find.widgetWithText(LabeledTextField, 'Login'));
+    await widgetTester.pumpAndSettle();
+  }
 
   setUpAll(() {
     registerFallbackValue(FakeUserCredentials());
@@ -39,8 +59,10 @@ void main() {
 
   setUp(() {
     mockAuthNotifier = MockAuthNotifier();
+    mockProbeService = MockServerProbeService();
     when(mockAuthNotifier.build).thenAnswer((_) async => true);
     when(() => mockAuthNotifier.login(any())).thenAnswer((_) async => null);
+    when(() => mockProbeService.probe(any())).thenAnswer((_) async => null);
   });
 
   group('LoginPage', () {
@@ -96,6 +118,169 @@ void main() {
         await widgetTester.tap(signInFinder);
         await widgetTester.pumpAndSettle();
         verify(() => mockAuthNotifier.login(credentials)).called(1);
+      },
+    );
+
+    testWidgets(
+      '- shows the discovered server when the url field loses focus',
+      (widgetTester) async {
+        when(() => mockProbeService.probe(any())).thenAnswer(
+          (_) async => const PublicSystemInfoDTO(
+            id: 'server-id',
+            serverName: 'Living Room',
+            version: '10.9.11',
+          ),
+        );
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pump(Duration.zero);
+        await enterServerUrlAndUnfocus(widgetTester, 'http://jelly.local');
+
+        verify(() => mockProbeService.probe('http://jelly.local')).called(1);
+        expect(find.text('Discovered: Living Room'), findsOneWidget);
+        expect(find.byIcon(Icons.check_circle), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      '- normalizes the url before probing it',
+      (widgetTester) async {
+        when(() => mockProbeService.probe(any())).thenAnswer(
+          (_) async => const PublicSystemInfoDTO(
+            id: 'server-id',
+            serverName: 'Living Room',
+            version: '10.9.11',
+          ),
+        );
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pump(Duration.zero);
+        await enterServerUrlAndUnfocus(widgetTester, 'jelly.local:8096');
+
+        verify(
+          () => mockProbeService.probe('http://jelly.local:8096'),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      '- shows nothing when the server is not a Jellyfin server',
+      (widgetTester) async {
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pump(Duration.zero);
+        await enterServerUrlAndUnfocus(widgetTester, 'http://nope.local');
+
+        verify(() => mockProbeService.probe('http://nope.local')).called(1);
+        expect(find.textContaining('Discovered:'), findsNothing);
+        expect(find.byIcon(Icons.check_circle), findsNothing);
+      },
+    );
+
+    testWidgets(
+      '- clears the discovered server when the url is edited',
+      (widgetTester) async {
+        when(() => mockProbeService.probe(any())).thenAnswer(
+          (_) async => const PublicSystemInfoDTO(
+            id: 'server-id',
+            serverName: 'Living Room',
+            version: '10.9.11',
+          ),
+        );
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pump(Duration.zero);
+        await enterServerUrlAndUnfocus(widgetTester, 'http://jelly.local');
+        expect(find.text('Discovered: Living Room'), findsOneWidget);
+
+        await widgetTester.enterText(
+          find.widgetWithText(LabeledTextField, 'Server URL'),
+          'http://jelly.local/other',
+        );
+        await widgetTester.pumpAndSettle();
+
+        expect(find.text('Discovered: Living Room'), findsNothing);
+        expect(find.byIcon(Icons.check_circle), findsNothing);
+      },
+    );
+
+    testWidgets(
+      '- shows the error returned by the login attempt',
+      (widgetTester) async {
+        when(() => mockAuthNotifier.login(any())).thenAnswer(
+          (_) async => AuthNotifier.invalidCredentialsError,
+        );
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pump(Duration.zero);
+        await widgetTester.enterText(
+          find.widgetWithText(LabeledTextField, 'Server URL'),
+          'http://jelly.local',
+        );
+        await widgetTester.enterText(
+          find.widgetWithText(LabeledTextField, 'Login'),
+          'alex',
+        );
+        final signInFinder = find.widgetWithText(ShadowedButton, 'Sign in');
+        await widgetTester.ensureVisible(signInFinder);
+        await widgetTester.pumpAndSettle();
+        await widgetTester.tap(signInFinder);
+        await widgetTester.pumpAndSettle();
+
+        expect(
+          find.text(AuthNotifier.invalidCredentialsError),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      '- requires a server url and a login',
+      (widgetTester) async {
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pump(Duration.zero);
+        final signInFinder = find.widgetWithText(ShadowedButton, 'Sign in');
+        await widgetTester.ensureVisible(signInFinder);
+        await widgetTester.pumpAndSettle();
+        await widgetTester.tap(signInFinder);
+        await widgetTester.pumpAndSettle();
+
+        expect(find.text('Server URL and login are required'), findsOneWidget);
+        verifyNever(() => mockAuthNotifier.login(any()));
+      },
+    );
+
+    testWidgets(
+      '- clears a previous error on the next attempt',
+      (widgetTester) async {
+        when(() => mockAuthNotifier.login(any())).thenAnswer(
+          (_) async => AuthNotifier.serverUnreachableError,
+        );
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pump(Duration.zero);
+        final signInFinder = find.widgetWithText(ShadowedButton, 'Sign in');
+        await widgetTester.ensureVisible(signInFinder);
+        await widgetTester.pumpAndSettle();
+        await widgetTester.tap(signInFinder);
+        await widgetTester.pumpAndSettle();
+        expect(find.text('Server URL and login are required'), findsOneWidget);
+
+        await widgetTester.enterText(
+          find.widgetWithText(LabeledTextField, 'Server URL'),
+          'http://jelly.local',
+        );
+        await widgetTester.enterText(
+          find.widgetWithText(LabeledTextField, 'Login'),
+          'alex',
+        );
+        await widgetTester.tap(signInFinder);
+        await widgetTester.pumpAndSettle();
+
+        expect(find.text('Server URL and login are required'), findsNothing);
+        expect(
+          find.text(AuthNotifier.serverUnreachableError),
+          findsOneWidget,
+        );
       },
     );
   });

--- a/test/providers/auth_provider_test.dart
+++ b/test/providers/auth_provider_test.dart
@@ -1,0 +1,114 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/main.dart';
+import 'package:jplayer/src/data/params/params.dart';
+import 'package:jplayer/src/data/providers/providers.dart';
+import 'package:jplayer/src/providers/auth_provider.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../provider_container.dart';
+
+class MockHttpClientAdapter extends Mock implements HttpClientAdapter {}
+
+class MockSecureStorage extends Mock implements FlutterSecureStorage {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockHttpClientAdapter mockAdapter;
+  late MockSecureStorage mockStorage;
+
+  const credentials = UserCredentials(
+    username: 'alex',
+    pw: 'hunter2',
+    serverUrl: 'http://jelly.local',
+  );
+
+  Future<String?> loginResult() async {
+    final container = createProviderContainer(
+      overrides: [secureStorageProvider.overrideWithValue(mockStorage)],
+    );
+    container.read(dioProvider).httpClientAdapter = mockAdapter;
+    await container.read(authProvider.future);
+    return container.read(authProvider.notifier).login(credentials);
+  }
+
+  void respondWithStatus(int statusCode) {
+    when(() => mockAdapter.fetch(any(), any(), any())).thenAnswer(
+      (_) async => ResponseBody.fromString(
+        jsonEncode({'error': 'nope'}),
+        statusCode,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      ),
+    );
+  }
+
+  setUpAll(() {
+    deviceId = 'test-device';
+    registerFallbackValue(RequestOptions(path: '/'));
+    registerFallbackValue(const Stream<Uint8List>.empty());
+  });
+
+  setUp(() {
+    mockAdapter = MockHttpClientAdapter();
+    mockStorage = MockSecureStorage();
+    when(
+      () => mockStorage.read(key: any(named: 'key')),
+    ).thenAnswer((_) async => null);
+    when(
+      () => mockStorage.write(
+        key: any(named: 'key'),
+        value: any(named: 'value'),
+      ),
+    ).thenAnswer((_) async {});
+    when(mockStorage.deleteAll).thenAnswer((_) async {});
+  });
+
+  group('AuthNotifier.login', () {
+    test('- reports bad credentials when the server answers 401', () async {
+      respondWithStatus(401);
+
+      expect(await loginResult(), AuthNotifier.invalidCredentialsError);
+    });
+
+    test('- reports bad credentials when the server answers 403', () async {
+      respondWithStatus(403);
+
+      expect(await loginResult(), AuthNotifier.invalidCredentialsError);
+    });
+
+    test('- reports an unreachable server on a connection timeout', () async {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenThrow(
+        DioException.connectionTimeout(
+          timeout: const Duration(seconds: 15),
+          requestOptions: RequestOptions(path: '/Users/AuthenticateByName'),
+        ),
+      );
+
+      expect(await loginResult(), AuthNotifier.serverUnreachableError);
+    });
+
+    test('- reports an unreachable server on a connection error', () async {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenThrow(
+        DioException.connectionError(
+          requestOptions: RequestOptions(path: '/Users/AuthenticateByName'),
+          reason: 'no route to host',
+        ),
+      );
+
+      expect(await loginResult(), AuthNotifier.serverUnreachableError);
+    });
+
+    test('- reports an unreachable server when the server errors', () async {
+      respondWithStatus(500);
+
+      expect(await loginResult(), AuthNotifier.serverUnreachableError);
+    });
+  });
+}


### PR DESCRIPTION
This PR resolves #161 - it seem like it was regression from a 1-year-old change done to auth page

Besides that I also improved UX on auth page:
* Added remote server related errors. Now when server is not available, or app can't access(ping it) - it will show error
* Added automated server url validation. Jellyfin has unauthenticated endpoint to get server data. Now on focus out from server url input - the app will try to communicate server and if it responds - there will be green message below server url input.
* Added auto library selection. Originally even if you had 1 lib in jellyfin - you'd still go through library selection screen. Now app just auto selects first(and only) lib and gets user to listen page. If user has multiple libs - then app will ask which lib to use