### PR TITLE
Wire Play Album button on mobile and tablet

### DIFF
--- a/lib/src/presentation/pages/album_page.dart
+++ b/lib/src/presentation/pages/album_page.dart
@@ -506,8 +506,32 @@ class _AlbumPageState extends ConsumerState<AlbumPage> {
   );
 
   Widget _playAlbumButton() => PlayButton(
-    onPressed: () {},
+    isLoading: ref.watch(setPlaybackProvider) == widget.album.id,
+    onPressed: _onPlayAlbumPressed,
   );
+
+  Future<void> _onPlayAlbumPressed() async {
+    try {
+      final result = await ref
+          .read(setPlaybackProvider.notifier)
+          .playAlbum(widget.album);
+      if (result == SetPlaybackResult.empty && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Nothing to play in "${widget.album.name}"'),
+          ),
+        );
+      }
+    } on Object catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Could not start playing "${widget.album.name}"'),
+          ),
+        );
+      }
+    }
+  }
 
   List<Widget> _suggestedAlbumsSlivers() {
     final albums = ref


### PR DESCRIPTION
This PR fixes "Play album" button on mobile and tablet UI to actually start album playback