### PR TITLE
Fix flac playback on macos/ios

### DIFF
--- a/lib/src/domain/providers/playback_provider.dart
+++ b/lib/src/domain/providers/playback_provider.dart
@@ -354,7 +354,15 @@ class PlaybackNotifier extends StateNotifier<PlaybackState> {
       song: song,
       source: useHls
           ? HlsAudioSource(audioSourceUri, tag: tag)
-          : AudioSource.uri(audioSourceUri, tag: tag),
+          : ProgressiveAudioSource(
+              audioSourceUri,
+              tag: tag,
+              options: const ProgressiveAudioSourceOptions(
+                darwinAssetOptions: DarwinAssetOptions(
+                  preferPreciseDurationAndTiming: true,
+                ),
+              ),
+            ),
     );
   }
 


### PR DESCRIPTION
This PR fixes issue with flac playback on ios/macos devices. In some cases the progress bar was showing as if song is over, but it kept playing. It also affected jumping to specirfic part of song via progress bar - it wasnt always moving playback to correct position. In this PR its fixed