### PR TITLE
Skip auth token validation when device offline

### DIFF
--- a/lib/src/data/backend/emby/emby_client.dart
+++ b/lib/src/data/backend/emby/emby_client.dart
@@ -492,12 +492,16 @@ class EmbyClient implements MediaServerClient {
   );
 
   @override
-  Future<bool> validateSession() async {
+  Future<SessionStatus> validateSession() async {
     try {
-      await _api.getArtists(userId: userId);
-      return true;
+      await _api.getArtists(userId: userId, limit: '1');
+      return SessionStatus.valid;
+    } on DioException catch (e) {
+      final statusCode = e.response?.statusCode;
+      if (statusCode == 401 || statusCode == 403) return SessionStatus.invalid;
+      return SessionStatus.unreachable;
     } on Object {
-      return false;
+      return SessionStatus.unreachable;
     }
   }
 

--- a/lib/src/data/backend/jellyfin/jellyfin_client.dart
+++ b/lib/src/data/backend/jellyfin/jellyfin_client.dart
@@ -480,12 +480,16 @@ class JellyfinClient implements MediaServerClient {
   );
 
   @override
-  Future<bool> validateSession() async {
+  Future<SessionStatus> validateSession() async {
     try {
-      await _api.getArtists(userId: userId);
-      return true;
+      await _api.getArtists(userId: userId, limit: '1');
+      return SessionStatus.valid;
+    } on DioException catch (e) {
+      final statusCode = e.response?.statusCode;
+      if (statusCode == 401 || statusCode == 403) return SessionStatus.invalid;
+      return SessionStatus.unreachable;
     } on Object {
-      return false;
+      return SessionStatus.unreachable;
     }
   }
 

--- a/lib/src/data/backend/media_server_client.dart
+++ b/lib/src/data/backend/media_server_client.dart
@@ -4,6 +4,8 @@ import 'package:jplayer/src/data/dto/dto.dart';
 import 'package:jplayer/src/data/params/params.dart';
 import 'package:jplayer/src/domain/models/models.dart';
 
+enum SessionStatus { valid, invalid, unreachable }
+
 abstract class MediaServerClient {
   Future<LibraryPage> getAlbums({
     required String userId,
@@ -176,7 +178,7 @@ abstract class MediaServerClient {
 
   Future<void> reportPlaybackStopped(PlaybackReport report);
 
-  Future<bool> validateSession();
+  Future<SessionStatus> validateSession();
 
   Future<void> signOut();
 }

--- a/lib/src/providers/auth_provider.dart
+++ b/lib/src/providers/auth_provider.dart
@@ -44,6 +44,8 @@ class AuthNotifier extends AsyncNotifier<bool?> {
       'Server is not accessible. Check the server URL and your connection.';
   static const invalidCredentialsError = 'Incorrect login or password';
 
+  static const _sessionValidationTimeout = Duration(seconds: 6);
+
   static const _serverUrlKey = 'serverUrl';
   static const _serverTypeKey = 'serverType';
   static const _serverIdKey = 'serverId';
@@ -87,18 +89,19 @@ class AuthNotifier extends AsyncNotifier<bool?> {
       userId: userId,
       token: token,
     );
-    final tokenValidated = await _validateSession(client, token, serverType);
+    final status = await _validateSession(client, token, serverType);
+    final sessionUsable = status != SessionStatus.invalid;
 
-    if (tokenValidated) {
+    if (sessionUsable) {
       ref.read(currentUserProvider.notifier).state = User(
         userId: userId,
         token: token,
       );
       _setAuthHeader(serverType, token);
-      await _adoptLegacyDownloads();
+      if (status == SessionStatus.valid) await _adoptLegacyDownloads();
     }
 
-    return tokenValidated && serverUrl.isNotEmpty && userId.isNotEmpty;
+    return sessionUsable && serverUrl.isNotEmpty && userId.isNotEmpty;
   }
 
   Future<String?> login(
@@ -143,12 +146,13 @@ class AuthNotifier extends AsyncNotifier<bool?> {
         userId: userId,
         token: token,
       );
-      final tokenValidated = await _validateSession(client, token, serverType);
-      if (tokenValidated) {
+      final status = await _validateSession(client, token, serverType);
+      final sessionUsable = status != SessionStatus.invalid;
+      if (sessionUsable) {
         _setAuthHeader(serverType, token);
         await _adoptLegacyDownloads();
       }
-      state = AsyncData(tokenValidated);
+      state = AsyncData(sessionUsable);
     } on DioException catch (e) {
       return _loginErrorMessage(e);
     }
@@ -315,20 +319,23 @@ class AuthNotifier extends AsyncNotifier<bool?> {
     return legacyToken;
   }
 
-  Future<bool> _validateSession(
+  Future<SessionStatus> _validateSession(
     MediaServerClient client,
     String? token,
     ServerType serverType,
   ) async {
-    if (token == null) return false;
+    if (token == null || token.isEmpty) return SessionStatus.invalid;
     try {
       _setAuthHeader(serverType, token);
-      final valid = await client.validateSession();
+      return await client.validateSession().timeout(
+        _sessionValidationTimeout,
+        onTimeout: () => SessionStatus.unreachable,
+      );
+    } on Object catch (e) {
+      log('Session validation failed: $e', name: 'Auth');
+      return SessionStatus.unreachable;
+    } finally {
       _removeAuthHeader();
-      return valid;
-    } catch (e) {
-      print('Error validating token: type=${e.runtimeType}, message=$e');
-      return false;
     }
   }
 


### PR DESCRIPTION
This PR fixes a bug related to offline mode. If app cold starts - it needs to validate token against server first. IN case when device is offline - request would time out and user prompted with login screen, being unable to access his downloads page.

This PR changes it, so when any request isnt 401 or 403 - it will render server as unreachable and allow users to get into app and see their local downloads