### PR TITLE
Jellyfin v12 authentication

### DIFF
--- a/lib/src/data/backend/emby/emby_auth_headers.dart
+++ b/lib/src/data/backend/emby/emby_auth_headers.dart
@@ -1,0 +1,25 @@
+import 'package:jplayer/src/data/backend/server_auth_headers.dart';
+
+class EmbyAuthHeaders extends ServerAuthHeaders {
+  const EmbyAuthHeaders({
+    required super.deviceId,
+    required super.deviceName,
+    required super.version,
+  });
+
+  static const authorizationHeader = 'x-emby-authorization';
+  static const tokenHeader = 'x-emby-token';
+
+  @override
+  Set<String> get managedKeys => const {authorizationHeader, tokenHeader};
+
+  @override
+  Map<String, String> build({String? token}) => {
+    authorizationHeader: mediaBrowserCredentials(
+      deviceId: deviceId,
+      deviceName: deviceName,
+      version: version,
+    ),
+    if (token != null && token.isNotEmpty) tokenHeader: token,
+  };
+}

--- a/lib/src/data/backend/jellyfin/jellyfin_auth_headers.dart
+++ b/lib/src/data/backend/jellyfin/jellyfin_auth_headers.dart
@@ -1,0 +1,24 @@
+import 'package:jplayer/src/data/backend/server_auth_headers.dart';
+
+class JellyfinAuthHeaders extends ServerAuthHeaders {
+  const JellyfinAuthHeaders({
+    required super.deviceId,
+    required super.deviceName,
+    required super.version,
+  });
+
+  static const authorizationHeader = 'authorization';
+
+  @override
+  Set<String> get managedKeys => const {authorizationHeader};
+
+  @override
+  Map<String, String> build({String? token}) => {
+    authorizationHeader: mediaBrowserCredentials(
+      deviceId: deviceId,
+      deviceName: deviceName,
+      version: version,
+      token: token,
+    ),
+  };
+}

--- a/lib/src/data/backend/jellyfin/jellyfin_client.dart
+++ b/lib/src/data/backend/jellyfin/jellyfin_client.dart
@@ -387,7 +387,7 @@ class JellyfinClient implements MediaServerClient {
       useHls ? 'Audio/${song.id}/main.m3u8' : 'Audio/${song.id}/universal',
       {
         'UserId': userId,
-        'api_key': token,
+        'ApiKey': token,
         'DeviceId': deviceId,
         'PlaySessionId': playSessionId,
         'MediaSourceId': audioSource?.id ?? song.id,

--- a/lib/src/data/backend/server_auth_headers.dart
+++ b/lib/src/data/backend/server_auth_headers.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+const clientName = 'JellyBox Player';
+
+String getCurrentPlatformName() {
+  if (Platform.isAndroid) {
+    return 'Android';
+  } else if (Platform.isIOS) {
+    return 'iOS';
+  } else if (Platform.isWindows) {
+    return 'Windows';
+  } else if (Platform.isMacOS) {
+    return 'macOS';
+  } else if (Platform.isLinux) {
+    return 'Linux';
+  } else {
+    return 'Unknown';
+  }
+}
+
+String mediaBrowserCredentials({
+  required String deviceId,
+  required String deviceName,
+  required String version,
+  String? token,
+}) {
+  final fields = <String>[
+    if (token != null && token.isNotEmpty) 'Token="$token"',
+    'Client="$clientName"',
+    'Device="$deviceName"',
+    'DeviceId="$deviceId"',
+    'Version="$version"',
+  ];
+  return 'MediaBrowser ${fields.join(', ')}';
+}
+
+abstract class ServerAuthHeaders {
+  const ServerAuthHeaders({
+    required this.deviceId,
+    required this.deviceName,
+    required this.version,
+  });
+
+  final String deviceId;
+  final String deviceName;
+  final String version;
+
+  Set<String> get managedKeys;
+
+  Map<String, String> build({String? token});
+}

--- a/lib/src/data/providers/dio_provider.dart
+++ b/lib/src/data/providers/dio_provider.dart
@@ -1,35 +1,14 @@
 import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:jplayer/main.dart';
-import 'package:jplayer/src/config/constants.dart';
 import 'package:jplayer/src/core/exceptions/exceptions.dart';
-
-String getCurrentPlatformName() {
-  if (Platform.isAndroid) {
-    return 'Android';
-  } else if (Platform.isIOS) {
-    return 'iOS';
-  } else if (Platform.isWindows) {
-    return 'Windows';
-  } else if (Platform.isMacOS) {
-    return 'macOS';
-  } else if (Platform.isLinux) {
-    return 'Linux';
-  } else {
-    return 'Unknown';
-  }
-}
 
 final dioProvider = Provider<Dio>(
   (ref) => Dio(
     BaseOptions(
       connectTimeout: const Duration(seconds: 15),
-      headers: {
-        'X-Emby-Authorization':
-            'MediaBrowser Client="JellyBox Player", Device="${getCurrentPlatformName()}", DeviceId="$deviceId", Version="$version"',
-      },
       contentType: 'application/json',
     ),
   )..interceptors.add(interceptor),

--- a/lib/src/providers/auth_provider.dart
+++ b/lib/src/providers/auth_provider.dart
@@ -7,10 +7,14 @@ import 'package:flutter/painting.dart' show PaintingBinding;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:jplayer/main.dart';
+import 'package:jplayer/src/config/constants.dart';
 import 'package:jplayer/src/data/api/api.dart';
+import 'package:jplayer/src/data/backend/emby/emby_auth_headers.dart';
 import 'package:jplayer/src/data/backend/emby/emby_client.dart';
+import 'package:jplayer/src/data/backend/jellyfin/jellyfin_auth_headers.dart';
 import 'package:jplayer/src/data/backend/jellyfin/jellyfin_client.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
+import 'package:jplayer/src/data/backend/server_auth_headers.dart';
 import 'package:jplayer/src/data/dto/dto.dart';
 import 'package:jplayer/src/data/params/params.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
@@ -52,10 +56,7 @@ class AuthNotifier extends AsyncNotifier<bool?> {
   static const _userIdKey = 'userId';
   static const _authTokenKey = 'authToken';
 
-  static const _jellyfinAuthHeader = 'x-mediabrowser-token';
-  static const _embyAuthHeader = 'x-emby-token';
-
-  static const _legacyAuthTokenKey = _jellyfinAuthHeader;
+  static const _legacyAuthTokenKey = 'x-mediabrowser-token';
 
   @override
   FutureOr<bool?> build() async {
@@ -123,6 +124,7 @@ class AuthNotifier extends AsyncNotifier<bool?> {
     UserCredentials credentials,
   ) async {
     try {
+      _setAuthHeader(serverType);
       final result = await _authenticate(serverType, serverUrl, credentials);
       final token = result.accessToken;
       final userId = result.user.id;
@@ -339,30 +341,48 @@ class AuthNotifier extends AsyncNotifier<bool?> {
     }
   }
 
-  void _setAuthHeader(ServerType serverType, String token) {
+  void _setAuthHeader(ServerType serverType, [String? token]) {
     _removeAuthHeader();
-    _client.options.headers[_authHeaderOf(serverType)] = token;
+    _client.options.headers.addAll(
+      _authHeadersOf(serverType).build(token: token),
+    );
 
     if (kDebugMode) _notifyDeveloper();
   }
 
   void _removeAuthHeader() {
-    _client.options.headers
-      ..remove(_jellyfinAuthHeader)
-      ..remove(_embyAuthHeader);
+    for (final serverType in ServerType.values) {
+      _authHeadersOf(serverType).managedKeys.forEach(
+        _client.options.headers.remove,
+      );
+    }
 
     if (kDebugMode) _notifyDeveloper();
   }
 
-  String _authHeaderOf(ServerType serverType) => switch (serverType) {
-    ServerType.jellyfin => _jellyfinAuthHeader,
-    ServerType.emby => _embyAuthHeader,
-  };
+  ServerAuthHeaders _authHeadersOf(ServerType serverType) {
+    final deviceName = getCurrentPlatformName();
+    return switch (serverType) {
+      ServerType.jellyfin => JellyfinAuthHeaders(
+        deviceId: deviceId,
+        deviceName: deviceName,
+        version: version,
+      ),
+      ServerType.emby => EmbyAuthHeaders(
+        deviceId: deviceId,
+        deviceName: deviceName,
+        version: version,
+      ),
+    };
+  }
 
   void _notifyDeveloper() => log(
-    (_client.options.headers[_jellyfinAuthHeader] ??
-            _client.options.headers[_embyAuthHeader])
-        .toString(),
+    {
+      for (final serverType in ServerType.values)
+        for (final key in _authHeadersOf(serverType).managedKeys)
+          if (_client.options.headers.containsKey(key))
+            key: _client.options.headers[key],
+    }.toString(),
     name: 'Auth',
   );
 }

--- a/test/data/backend/jellyfin/jellyfin_client_test.dart
+++ b/test/data/backend/jellyfin/jellyfin_client_test.dart
@@ -67,7 +67,7 @@ void main() {
       expect(source.outputContainer, 'mp3');
       expect(source.uri.path, '/Audio/song-1/universal');
       expect(source.uri.queryParameters['UserId'], 'user-1');
-      expect(source.uri.queryParameters['api_key'], 'token-1');
+      expect(source.uri.queryParameters['ApiKey'], 'token-1');
       expect(source.uri.queryParameters['DeviceId'], 'device-1');
       expect(source.uri.queryParameters['PlaySessionId'], 'session-1');
       expect(source.uri.queryParameters['MediaSourceId'], 'song-1');

--- a/test/providers/auth_provider_test.dart
+++ b/test/providers/auth_provider_test.dart
@@ -126,6 +126,98 @@ void main() {
     });
   });
 
+  group('AuthNotifier authorization headers', () {
+    final requests = <RequestOptions>[];
+
+    void respondToSignIn() {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenAnswer((
+        invocation,
+      ) async {
+        final options = invocation.positionalArguments.first as RequestOptions;
+        requests.add(options);
+        final body = options.path.contains('AuthenticateByName')
+            ? jsonEncode({
+                'User': {'Id': 'user-1', 'Name': 'alex'},
+                'SessionInfo': {
+                  'Id': 'session-1',
+                  'PlayState': <String, dynamic>{},
+                },
+                'AccessToken': 'token-1',
+                'ServerId': 'server-1',
+              })
+            : jsonEncode({'Items': <dynamic>[], 'TotalRecordCount': 0});
+        return ResponseBody.fromString(
+          body,
+          200,
+          headers: {
+            Headers.contentTypeHeader: [Headers.jsonContentType],
+          },
+        );
+      });
+    }
+
+    Future<Dio> signIn(ServerType serverType) async {
+      final container = createProviderContainer(
+        overrides: [secureStorageProvider.overrideWithValue(mockStorage)],
+      );
+      final dio = container.read(dioProvider)..httpClientAdapter = mockAdapter;
+      await container.read(authProvider.future);
+      await container
+          .read(authProvider.notifier)
+          .login(credentials, serverType: serverType);
+      return dio;
+    }
+
+    Map<String, dynamic> signInHeaders() => requests
+        .firstWhere((request) => request.path.contains('AuthenticateByName'))
+        .headers;
+
+    setUp(() {
+      requests.clear();
+      respondToSignIn();
+    });
+
+    test(
+      '- identifies the client to Jellyfin through the Authorization header, '
+      'which is the only form Jellyfin 12 still parses',
+      () async {
+        final dio = await signIn(ServerType.jellyfin);
+
+        final sent = signInHeaders()['authorization'] as String;
+        expect(sent, startsWith('MediaBrowser '));
+        expect(sent, contains('Client="JellyBox Player"'));
+        expect(sent, contains('DeviceId="test-device"'));
+        expect(sent, isNot(contains('Token=')));
+        expect(signInHeaders().containsKey('x-emby-authorization'), isFalse);
+
+        expect(
+          dio.options.headers['authorization'],
+          contains('Token="token-1"'),
+        );
+        expect(
+          dio.options.headers.containsKey('x-mediabrowser-token'),
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      '- keeps identifying the client to Emby through X-Emby-Authorization',
+      () async {
+        final dio = await signIn(ServerType.emby);
+
+        final sent = signInHeaders()['x-emby-authorization'] as String;
+        expect(sent, startsWith('MediaBrowser '));
+        expect(sent, contains('Client="JellyBox Player"'));
+        expect(sent, contains('DeviceId="test-device"'));
+        expect(signInHeaders().containsKey('authorization'), isFalse);
+
+        expect(dio.options.headers['x-emby-token'], 'token-1');
+        expect(dio.options.headers.containsKey('authorization'), isFalse);
+      },
+    );
+  });
+
   group('AuthNotifier.build', () {
     test(
       '- migrates a token stored under the pre-refactor key name so '


### PR DESCRIPTION
This PR adds a new way to attach tokens in jellyfin requests. On some instances it was already enforced, making player unusable on them. This PR fixes it