### PR TITLE
Emby/jellyfin server discovery

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -70,6 +70,8 @@
 			</array>
 		</dict>
 	</dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>JellyBox looks for Jellyfin and Emby servers on your local network so you can sign in without typing an address.</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -6,5 +6,7 @@
 	<string>development</string>
 	<key>com.apple.developer.carplay-audio</key>
 	<true/>
+	<key>com.apple.developer.networking.multicast</key>
+	<true/>
 </dict>
 </plist>

--- a/lib/src/data/backend/emby/emby_discovery.dart
+++ b/lib/src/data/backend/emby/emby_discovery.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:jplayer/src/data/backend/server_discovery_protocol.dart';
+import 'package:jplayer/src/data/services/server_probe_service.dart';
+
+class EmbyDiscovery extends ServerDiscoveryProtocol {
+  const EmbyDiscovery({this.port = 7359, this.httpPort = 8096});
+
+  @override
+  final int port;
+
+  final int httpPort;
+
+  @override
+  ServerType get serverType => ServerType.emby;
+
+  @override
+  String get probe => 'who is EmbyServer?';
+
+  @override
+  ServerAnnouncement? parse(Datagram datagram) => parseMediaBrowserAnnouncement(
+    datagram,
+    serverType: serverType,
+    defaultHttpPort: httpPort,
+  );
+}

--- a/lib/src/data/backend/jellyfin/jellyfin_discovery.dart
+++ b/lib/src/data/backend/jellyfin/jellyfin_discovery.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:jplayer/src/data/backend/server_discovery_protocol.dart';
+import 'package:jplayer/src/data/services/server_probe_service.dart';
+
+class JellyfinDiscovery extends ServerDiscoveryProtocol {
+  const JellyfinDiscovery({this.port = 7359, this.httpPort = 8096});
+
+  @override
+  final int port;
+
+  final int httpPort;
+
+  @override
+  ServerType get serverType => ServerType.jellyfin;
+
+  @override
+  String get probe => 'who is JellyfinServer?';
+
+  @override
+  ServerAnnouncement? parse(Datagram datagram) => parseMediaBrowserAnnouncement(
+    datagram,
+    serverType: serverType,
+    defaultHttpPort: httpPort,
+  );
+}

--- a/lib/src/data/backend/server_discovery_protocol.dart
+++ b/lib/src/data/backend/server_discovery_protocol.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:jplayer/src/data/services/server_probe_service.dart';
+
+class ServerAnnouncement {
+  const ServerAnnouncement({
+    required this.id,
+    required this.address,
+    required this.serverType,
+    this.name,
+    this.sourceAddress,
+  });
+
+  final String id;
+  final String address;
+  final ServerType serverType;
+  final String? name;
+  final String? sourceAddress;
+}
+
+abstract class ServerDiscoveryProtocol {
+  const ServerDiscoveryProtocol();
+
+  ServerType get serverType;
+
+  int get port;
+
+  String get probe;
+
+  ServerAnnouncement? parse(Datagram datagram);
+}
+
+ServerAnnouncement? parseMediaBrowserAnnouncement(
+  Datagram datagram, {
+  required ServerType serverType,
+  required int defaultHttpPort,
+}) {
+  final Object? payload;
+  try {
+    payload = jsonDecode(utf8.decode(datagram.data));
+  } on Object {
+    return null;
+  }
+  if (payload is! Map<String, dynamic>) return null;
+  if (!payload.containsKey('Address') && !payload.containsKey('Id')) {
+    return null;
+  }
+
+  final sender = 'http://${datagram.address.address}:$defaultHttpPort';
+  final address = _text(payload['Address']) ?? sender;
+  return ServerAnnouncement(
+    id: _text(payload['Id']) ?? address,
+    address: normalizeServerUrl(address),
+    serverType: serverType,
+    name: _text(payload['Name']),
+    sourceAddress: sender,
+  );
+}
+
+String? _text(Object? value) {
+  if (value is! String) return null;
+  final trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}

--- a/lib/src/data/providers/providers.dart
+++ b/lib/src/data/providers/providers.dart
@@ -5,5 +5,6 @@ export 'media_server_client_provider.dart';
 export 'playback_storage_provider.dart';
 export 'search_provider.dart';
 export 'secure_storage_provider.dart';
+export 'server_discovery_provider.dart';
 export 'server_probe_provider.dart';
 export 'shared_preferences_provider.dart';

--- a/lib/src/data/providers/server_discovery_provider.dart
+++ b/lib/src/data/providers/server_discovery_provider.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jplayer/src/data/backend/emby/emby_discovery.dart';
+import 'package:jplayer/src/data/backend/jellyfin/jellyfin_discovery.dart';
+import 'package:jplayer/src/data/services/server_discovery_service.dart';
+
+final serverDiscoveryServiceProvider = Provider<ServerDiscoveryService>(
+  (ref) => ServerDiscoveryService(
+    protocols: const [JellyfinDiscovery(), EmbyDiscovery()],
+  ),
+);

--- a/lib/src/data/services/server_discovery_service.dart
+++ b/lib/src/data/services/server_discovery_service.dart
@@ -1,0 +1,187 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:jplayer/src/data/backend/server_discovery_protocol.dart';
+
+class ServerDiscoveryService {
+  ServerDiscoveryService({
+    required List<ServerDiscoveryProtocol> protocols,
+    List<InternetAddress>? targets,
+    Future<List<InternetAddress>> Function()? localAddresses,
+  }) : _protocols = protocols,
+       _targets = targets,
+       _localAddresses = localAddresses ?? _defaultLocalAddresses;
+
+  static final limitedBroadcast = InternetAddress('255.255.255.255');
+
+  final List<ServerDiscoveryProtocol> _protocols;
+  final List<InternetAddress>? _targets;
+  final Future<List<InternetAddress>> Function() _localAddresses;
+
+  Stream<ServerAnnouncement> discover({
+    Duration timeout = const Duration(seconds: 4),
+    Duration retryInterval = const Duration(milliseconds: 900),
+  }) => _DiscoveryRun(
+    protocols: _protocols,
+    localAddresses: _localAddresses,
+    targetsFor: targetsFor,
+    timeout: timeout,
+    retryInterval: retryInterval,
+  ).stream;
+
+  List<InternetAddress> targetsFor(InternetAddress address) {
+    final overrides = _targets;
+    if (overrides != null) return overrides;
+    final directed = directedBroadcastFor(address);
+    return [limitedBroadcast, ?directed];
+  }
+}
+
+class _DiscoveryRun {
+  _DiscoveryRun({
+    required this.protocols,
+    required this.localAddresses,
+    required this.targetsFor,
+    required this.timeout,
+    required this.retryInterval,
+  }) {
+    _controller
+      ..onListen = _start
+      ..onCancel = _closeSockets;
+  }
+
+  final List<ServerDiscoveryProtocol> protocols;
+  final Future<List<InternetAddress>> Function() localAddresses;
+  final List<InternetAddress> Function(InternetAddress) targetsFor;
+  final Duration timeout;
+  final Duration retryInterval;
+
+  final _controller = StreamController<ServerAnnouncement>();
+  final _probes = <_Probe>[];
+  final _seen = <String>{};
+  Timer? _deadline;
+  Timer? _repeat;
+  var _stopped = false;
+
+  Stream<ServerAnnouncement> get stream => _controller.stream;
+
+  Future<void> _start() async {
+    try {
+      await _openSockets();
+      if (_stopped) return;
+      if (_probes.isEmpty) return _finish();
+      _announce();
+      _repeat = Timer.periodic(retryInterval, (_) => _announce());
+      _deadline = Timer(timeout, _finish);
+    } on Object {
+      await _finish();
+    }
+  }
+
+  Future<void> _openSockets() async {
+    for (final address in await localAddresses()) {
+      for (final protocol in protocols) {
+        for (final target in targetsFor(address)) {
+          if (_stopped) return;
+          final probe = await _Probe.bind(address, protocol, target, _receive);
+          if (probe != null) _probes.add(probe);
+        }
+      }
+    }
+  }
+
+  void _announce() {
+    for (final probe in _probes) {
+      probe.send();
+    }
+  }
+
+  void _receive(_Probe probe) {
+    final datagram = probe.socket.receive();
+    if (datagram == null) return;
+    final announcement = probe.protocol.parse(datagram);
+    if (announcement == null) return;
+    final key = '${probe.protocol.serverType.name}|${announcement.id}';
+    if (!_seen.add(key)) return;
+    if (!_controller.isClosed) _controller.add(announcement);
+  }
+
+  void _closeSockets() {
+    _stopped = true;
+    _deadline?.cancel();
+    _repeat?.cancel();
+    for (final probe in _probes) {
+      probe.socket.close();
+    }
+    _probes.clear();
+  }
+
+  Future<void> _finish() async {
+    if (_stopped) return;
+    _closeSockets();
+    if (!_controller.isClosed) await _controller.close();
+  }
+}
+
+class _Probe {
+  _Probe(this.socket, this.protocol, this.target);
+
+  static Future<_Probe?> bind(
+    InternetAddress address,
+    ServerDiscoveryProtocol protocol,
+    InternetAddress target,
+    void Function(_Probe probe) onDatagram,
+  ) async {
+    try {
+      final socket = await RawDatagramSocket.bind(address, 0);
+      final probe = _Probe(socket, protocol, target);
+      socket
+        ..broadcastEnabled = true
+        ..listen(
+          (event) {
+            if (event == RawSocketEvent.read) onDatagram(probe);
+          },
+          onError: (Object _) {},
+        );
+      return probe;
+    } on Object {
+      return null;
+    }
+  }
+
+  final RawDatagramSocket socket;
+  final ServerDiscoveryProtocol protocol;
+  final InternetAddress target;
+
+  void send() {
+    try {
+      socket.send(utf8.encode(protocol.probe), target, protocol.port);
+    } on Object {
+      return;
+    }
+  }
+}
+
+InternetAddress? directedBroadcastFor(InternetAddress address) {
+  if (address.type != InternetAddressType.IPv4) return null;
+  if (address.address == InternetAddress.anyIPv4.address) return null;
+  final octets = address.address.split('.');
+  if (octets.length != 4) return null;
+  if (octets.any((octet) => int.tryParse(octet) == null)) return null;
+  return InternetAddress('${octets[0]}.${octets[1]}.${octets[2]}.255');
+}
+
+Future<List<InternetAddress>> _defaultLocalAddresses() async {
+  try {
+    final interfaces = await NetworkInterface.list(
+      type: InternetAddressType.IPv4,
+    );
+    return [
+      InternetAddress.anyIPv4,
+      for (final interface in interfaces) ...interface.addresses,
+    ];
+  } on Object {
+    return [InternetAddress.anyIPv4];
+  }
+}

--- a/lib/src/domain/providers/discovered_servers_provider.dart
+++ b/lib/src/domain/providers/discovered_servers_provider.dart
@@ -1,0 +1,146 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jplayer/src/data/backend/server_discovery_protocol.dart';
+import 'package:jplayer/src/data/providers/providers.dart';
+import 'package:jplayer/src/data/services/server_discovery_service.dart';
+import 'package:jplayer/src/data/services/server_probe_service.dart';
+
+class DiscoveredServer {
+  const DiscoveredServer({
+    required this.id,
+    required this.name,
+    required this.serverUrl,
+    required this.serverType,
+  });
+
+  final String id;
+  final String name;
+  final String serverUrl;
+  final ServerType serverType;
+}
+
+class ServerDiscoveryState {
+  const ServerDiscoveryState({
+    this.scanning = false,
+    this.finished = false,
+    this.servers = const [],
+  });
+
+  final bool scanning;
+  final bool finished;
+  final List<DiscoveredServer> servers;
+
+  bool get foundNothing => finished && servers.isEmpty;
+
+  ServerDiscoveryState copyWith({
+    bool? scanning,
+    bool? finished,
+    List<DiscoveredServer>? servers,
+  }) => ServerDiscoveryState(
+    scanning: scanning ?? this.scanning,
+    finished: finished ?? this.finished,
+    servers: servers ?? this.servers,
+  );
+}
+
+class ServerDiscoveryNotifier extends StateNotifier<ServerDiscoveryState> {
+  ServerDiscoveryNotifier({
+    required ServerDiscoveryService discovery,
+    required ServerProbeService probe,
+  }) : _discovery = discovery,
+       _probe = probe,
+       super(const ServerDiscoveryState());
+
+  final ServerDiscoveryService _discovery;
+  final ServerProbeService _probe;
+
+  StreamSubscription<ServerAnnouncement>? _subscription;
+  Completer<void>? _done;
+  int _generation = 0;
+
+  Future<void> scan() async {
+    final generation = ++_generation;
+    await _subscription?.cancel();
+    _completeDone();
+    state = const ServerDiscoveryState(scanning: true);
+
+    final resolving = <Future<void>>[];
+    final done = _done = Completer<void>();
+    _subscription = _discovery.discover().listen(
+      (announcement) => resolving.add(_resolve(announcement, generation)),
+      onError: (Object _) => _completeDone(),
+      onDone: _completeDone,
+    );
+
+    await done.future;
+    await Future.wait(resolving);
+    if (generation != _generation || !mounted) return;
+    state = state.copyWith(scanning: false, finished: true);
+  }
+
+  Future<void> _resolve(ServerAnnouncement announcement, int generation) async {
+    final result =
+        await _probe.discover(announcement.address) ??
+        await _probeSourceAddress(announcement);
+    if (result == null || generation != _generation || !mounted) return;
+    if (state.servers.any((server) => server.serverUrl == result.serverUrl)) {
+      return;
+    }
+
+    final server = DiscoveredServer(
+      id: announcement.id,
+      name:
+          result.info.serverName ??
+          announcement.name ??
+          Uri.parse(result.serverUrl).host,
+      serverUrl: result.serverUrl,
+      serverType: result.serverType,
+    );
+    state = state.copyWith(servers: [...state.servers, server]);
+  }
+
+  void cancel() {
+    _generation++;
+    unawaited(_subscription?.cancel());
+    _completeDone();
+    if (!mounted) return;
+    state = state.copyWith(scanning: false, finished: true);
+  }
+
+  Future<ServerProbeResult?> _probeSourceAddress(
+    ServerAnnouncement announcement,
+  ) async {
+    final source = announcement.sourceAddress;
+    if (source == null || source == announcement.address) return null;
+    return _probe.discover(source);
+  }
+
+  void _completeDone() {
+    final done = _done;
+    if (done != null && !done.isCompleted) done.complete();
+  }
+
+  @override
+  void dispose() {
+    _generation++;
+    unawaited(_subscription?.cancel());
+    _completeDone();
+    super.dispose();
+  }
+}
+
+final AutoDisposeStateNotifierProvider<
+  ServerDiscoveryNotifier,
+  ServerDiscoveryState
+>
+serverDiscoveryProvider =
+    StateNotifierProvider.autoDispose<
+      ServerDiscoveryNotifier,
+      ServerDiscoveryState
+    >(
+      (ref) => ServerDiscoveryNotifier(
+        discovery: ref.watch(serverDiscoveryServiceProvider),
+        probe: ref.watch(serverProbeServiceProvider),
+      ),
+    );

--- a/lib/src/domain/providers/providers.dart
+++ b/lib/src/domain/providers/providers.dart
@@ -4,6 +4,7 @@ export 'current_day_provider.dart';
 export 'current_library_provider.dart';
 export 'current_playlist_provider.dart';
 export 'current_user_provider.dart';
+export 'discovered_servers_provider.dart';
 export 'download_manager_provider.dart';
 export 'downloaded_albums_provider.dart';
 export 'favourites_provider.dart';

--- a/lib/src/presentation/pages/login_page.dart
+++ b/lib/src/presentation/pages/login_page.dart
@@ -7,6 +7,7 @@ import 'package:jplayer/resources/resources.dart';
 import 'package:jplayer/src/data/params/params.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
 import 'package:jplayer/src/data/services/server_probe_service.dart';
+import 'package:jplayer/src/domain/providers/discovered_servers_provider.dart';
 import 'package:jplayer/src/presentation/widgets/widgets.dart';
 import 'package:jplayer/src/providers/auth_provider.dart';
 
@@ -24,15 +25,23 @@ class LoginPageState extends ConsumerState<LoginPage> {
   final _passwordInputController = TextEditingController();
   final _serverUrlFocusNode = FocusNode();
 
-  ServerProbeResult? _discoveredServer;
+  String? _resolvedServerUrl;
+  ServerType? _resolvedServerType;
   String? _probedInput;
   int _probeGeneration = 0;
+
+  ServerUrlFieldMode _mode = ServerUrlFieldMode.discovering;
+  DiscoveredServer? _selectedServer;
+  bool _manualEntry = false;
 
   @override
   void initState() {
     super.initState();
     _serverUrlFocusNode.addListener(_onServerUrlFocusChange);
     _serverUrlInputController.addListener(_onServerUrlChanged);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) unawaited(ref.read(serverDiscoveryProvider.notifier).scan());
+    });
   }
 
   @override
@@ -53,9 +62,62 @@ class LoginPageState extends ConsumerState<LoginPage> {
   }
 
   void _onServerUrlChanged() {
+    final text = _serverUrlInputController.text.trim();
+    if (!_manualEntry && text.isNotEmpty) _startManualEntry();
     if (_probedInput == null) return;
-    if (_serverUrlInputController.text.trim() == _probedInput) return;
+    if (text == _probedInput) return;
     _resetDiscoveredServer();
+  }
+
+  void _startManualEntry() {
+    ref.read(serverDiscoveryProvider.notifier).cancel();
+    _manualEntry = true;
+    setState(() {
+      _mode = ServerUrlFieldMode.manual;
+      _selectedServer = null;
+    });
+  }
+
+  void _onDiscoveryChanged(ServerDiscoveryState discovery) {
+    if (_manualEntry) return;
+    if (discovery.servers.isNotEmpty) {
+      if (_selectedServer == null) _selectServer(discovery.servers.first);
+      return;
+    }
+    if (discovery.finished && _mode == ServerUrlFieldMode.discovering) {
+      setState(() => _mode = ServerUrlFieldMode.manual);
+    }
+  }
+
+  void _selectServer(DiscoveredServer server) {
+    setState(() {
+      error = null;
+      _selectedServer = server;
+      _mode = ServerUrlFieldMode.selected;
+      _resolvedServerUrl = server.serverUrl;
+      _resolvedServerType = server.serverType;
+    });
+  }
+
+  void _editSelectedServer() {
+    final server = _selectedServer;
+    ref.read(serverDiscoveryProvider.notifier).cancel();
+    _manualEntry = true;
+    _probedInput = server?.serverUrl;
+    if (server != null) _serverUrlInputController.text = server.serverUrl;
+    setState(() {
+      _selectedServer = null;
+      _mode = ServerUrlFieldMode.manual;
+    });
+    _serverUrlFocusNode.requestFocus();
+  }
+
+  String get _effectiveServerUrl {
+    final server = _selectedServer;
+    if (server != null) return server.serverUrl;
+    final raw = _serverUrlInputController.text.trim();
+    if (raw.isEmpty) return '';
+    return _resolvedServerUrl ?? normalizeServerUrl(raw);
   }
 
   Future<void> _probeServer() async {
@@ -68,33 +130,39 @@ class LoginPageState extends ConsumerState<LoginPage> {
 
     final generation = ++_probeGeneration;
     _probedInput = rawUrl;
-    if (_discoveredServer != null) {
-      setState(() => _discoveredServer = null);
+    if (_resolvedServerType != null) {
+      setState(() {
+        _resolvedServerUrl = null;
+        _resolvedServerType = null;
+      });
     }
 
     final result = await ref.read(serverProbeServiceProvider).discover(rawUrl);
     if (!mounted || generation != _probeGeneration) return;
 
-    setState(() => _discoveredServer = result);
+    setState(() {
+      _resolvedServerUrl = result?.serverUrl;
+      _resolvedServerType = result?.serverType;
+    });
   }
 
   void _resetDiscoveredServer() {
     _probeGeneration++;
     _probedInput = null;
-    if (_discoveredServer == null) return;
-    setState(() => _discoveredServer = null);
+    if (_resolvedServerType == null) return;
+    setState(() {
+      _resolvedServerUrl = null;
+      _resolvedServerType = null;
+    });
   }
 
   Future<void> signIn() async {
     if (error != null) setState(() => error = null);
 
-    final rawServerUrl = _serverUrlInputController.text.trim();
     final credentials = UserCredentials(
       username: _emailInputController.text.trim(),
       pw: _passwordInputController.text.trim(),
-      serverUrl: rawServerUrl.isEmpty
-          ? ''
-          : _discoveredServer?.serverUrl ?? normalizeServerUrl(rawServerUrl),
+      serverUrl: _effectiveServerUrl,
     );
     if (credentials.serverUrl.isEmpty || credentials.username.isEmpty) {
       setState(() {
@@ -116,7 +184,7 @@ class LoginPageState extends ConsumerState<LoginPage> {
         .read(authProvider.notifier)
         .login(
           credentials,
-          serverType: _discoveredServer?.serverType ?? ServerType.jellyfin,
+          serverType: _resolvedServerType ?? ServerType.jellyfin,
         );
     if (resp != null && mounted) {
       setState(() {
@@ -127,6 +195,7 @@ class LoginPageState extends ConsumerState<LoginPage> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen(serverDiscoveryProvider, (_, next) => _onDiscoveryChanged(next));
     return Scaffold(
       body: SafeArea(
         minimum: const EdgeInsets.symmetric(vertical: 36, horizontal: 48),
@@ -152,7 +221,7 @@ class LoginPageState extends ConsumerState<LoginPage> {
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
                         LoginLogo(
-                          serverType: _discoveredServer?.serverType,
+                          serverType: _resolvedServerType,
                         ),
                         const SizedBox(height: 63),
                         _serverURLField(),
@@ -193,19 +262,23 @@ class LoginPageState extends ConsumerState<LoginPage> {
     mainAxisSize: MainAxisSize.min,
     crossAxisAlignment: CrossAxisAlignment.start,
     children: [
-      LabeledTextField(
-        label: 'Server URL',
-        keyboardType: TextInputType.url,
+      ServerUrlField(
+        mode: _mode,
         controller: _serverUrlInputController,
         focusNode: _serverUrlFocusNode,
-        textInputAction: TextInputAction.next,
+        servers: ref.watch(serverDiscoveryProvider).servers,
+        scanning: ref.watch(serverDiscoveryProvider).scanning,
+        selected: _selectedServer,
+        onEdit: _editSelectedServer,
+        onSelect: _selectServer,
         suffixIcon: _serverUrlSuffixIcon(),
       ),
-      if (_discoveredServer != null) _discoveredServerText(_discoveredServer!),
+      if (_mode != ServerUrlFieldMode.selected && _resolvedServerType != null)
+        _discoveredServerText(_resolvedServerType!),
     ],
   );
 
-  Widget? _serverUrlSuffixIcon() => (_discoveredServer != null)
+  Widget? _serverUrlSuffixIcon() => (_resolvedServerType != null)
       ? Icon(
           Icons.check_circle,
           color: Theme.of(context).colorScheme.secondary,
@@ -213,10 +286,10 @@ class LoginPageState extends ConsumerState<LoginPage> {
         )
       : null;
 
-  Widget _discoveredServerText(ServerProbeResult server) => Padding(
+  Widget _discoveredServerText(ServerType serverType) => Padding(
     padding: const EdgeInsets.only(top: 4),
     child: Text(
-      'Discovered: ${server.serverType.label} server',
+      'Discovered: ${serverType.label} server',
       style: TextStyle(
         fontFamily: FontFamily.inter,
         fontSize: 12,

--- a/lib/src/presentation/widgets/server_url_field.dart
+++ b/lib/src/presentation/widgets/server_url_field.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:jplayer/resources/resources.dart';
+import 'package:jplayer/src/data/services/server_probe_service.dart';
+import 'package:jplayer/src/domain/providers/discovered_servers_provider.dart';
+import 'package:jplayer/src/presentation/widgets/labeled_text_field.dart';
+
+enum ServerUrlFieldMode { discovering, manual, selected }
+
+class ServerUrlField extends StatefulWidget {
+  const ServerUrlField({
+    required this.mode,
+    required this.controller,
+    required this.focusNode,
+    required this.servers,
+    required this.onEdit,
+    required this.onSelect,
+    this.selected,
+    this.suffixIcon,
+    this.scanning = false,
+    super.key,
+  });
+
+  static const label = 'Server URL';
+  static const discoveringPlaceholder = 'Auto discovering...';
+  static const ValueKey<String> surfaceKey = ValueKey(
+    'serverUrlFieldSurface',
+  );
+  static const fillColor = Color(0xFFEEEEEE);
+  static const radius = 10.0;
+
+  final ServerUrlFieldMode mode;
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final List<DiscoveredServer> servers;
+  final DiscoveredServer? selected;
+  final VoidCallback onEdit;
+  final ValueChanged<DiscoveredServer> onSelect;
+  final Widget? suffixIcon;
+  final bool scanning;
+
+  @override
+  State<ServerUrlField> createState() => _ServerUrlFieldState();
+}
+
+class _ServerUrlFieldState extends State<ServerUrlField> {
+  bool _menuOpen = false;
+
+  BorderRadius get _surfaceRadius => _menuOpen
+      ? const BorderRadius.vertical(top: Radius.circular(ServerUrlField.radius))
+      : BorderRadius.circular(ServerUrlField.radius);
+
+  @override
+  Widget build(BuildContext context) {
+    final server = widget.selected;
+    if (widget.mode != ServerUrlFieldMode.selected || server == null) {
+      return LabeledTextField(
+        label: ServerUrlField.label,
+        placeholder: widget.mode == ServerUrlFieldMode.discovering
+            ? ServerUrlField.discoveringPlaceholder
+            : null,
+        keyboardType: TextInputType.url,
+        controller: widget.controller,
+        focusNode: widget.focusNode,
+        textInputAction: TextInputAction.next,
+        suffixIcon: widget.mode == ServerUrlFieldMode.discovering
+            ? const DiscoveringSpinner()
+            : widget.suffixIcon,
+      );
+    }
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          ServerUrlField.label,
+          style: TextStyle(fontFamily: FontFamily.inter, fontSize: 12),
+        ),
+        const SizedBox(height: 4),
+        _selectedServer(server),
+      ],
+    );
+  }
+
+  Widget _selectedServer(DiscoveredServer server) {
+    final expandable = widget.servers.length > 1;
+    return Builder(
+      builder: (fieldContext) => Material(
+        key: ServerUrlField.surfaceKey,
+        color: ServerUrlField.fillColor,
+        borderRadius: _surfaceRadius,
+        child: Row(
+          children: [
+            Expanded(
+              child: InkWell(
+                onTap: expandable ? () => _openDropdown(fieldContext) : null,
+                borderRadius: _surfaceRadius,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(12, 8, 4, 8),
+                  child: Row(
+                    children: [
+                      Expanded(child: serverSummary(server)),
+                      if (widget.scanning) const DiscoveringSpinner(),
+                      if (expandable)
+                        const Icon(
+                          Icons.keyboard_arrow_down,
+                          color: Colors.black54,
+                          size: 22,
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            IconButton(
+              onPressed: widget.onEdit,
+              visualDensity: VisualDensity.compact,
+              tooltip: 'Enter a server address',
+              icon: const Icon(Icons.edit, color: Colors.black54, size: 20),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openDropdown(BuildContext context) async {
+    final box = context.findRenderObject() as RenderBox?;
+    final overlay =
+        Overlay.of(context).context.findRenderObject() as RenderBox?;
+    if (box == null || overlay == null) return;
+
+    final topLeft = box.localToGlobal(
+      box.size.bottomLeft(Offset.zero),
+      ancestor: overlay,
+    );
+    final bottomRight = box.localToGlobal(
+      box.size.bottomRight(Offset.zero),
+      ancestor: overlay,
+    );
+
+    setState(() => _menuOpen = true);
+    final picked = await showMenu<DiscoveredServer>(
+      context: context,
+      color: ServerUrlField.fillColor,
+      position: RelativeRect.fromRect(
+        Rect.fromPoints(topLeft, bottomRight),
+        Offset.zero & overlay.size,
+      ),
+      constraints: BoxConstraints(
+        minWidth: box.size.width,
+        maxWidth: box.size.width,
+      ),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          bottom: Radius.circular(ServerUrlField.radius),
+        ),
+      ),
+      items: [
+        for (final server in widget.servers)
+          PopupMenuItem<DiscoveredServer>(
+            value: server,
+            padding: EdgeInsets.zero,
+            child: _HoverableServer(server: server),
+          ),
+      ],
+    );
+    if (mounted) setState(() => _menuOpen = false);
+    if (picked != null) widget.onSelect(picked);
+  }
+}
+
+Widget serverSummary(DiscoveredServer server) => Row(
+  children: [
+    SvgPicture.asset(_logoAsset(server.serverType), height: 22),
+    const SizedBox(width: 10),
+    Expanded(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            server.name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              fontFamily: FontFamily.inter,
+              fontSize: 15,
+              color: Colors.black87,
+            ),
+          ),
+          Text(
+            server.serverUrl,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              fontFamily: FontFamily.inter,
+              fontSize: 12,
+              color: Colors.black54,
+            ),
+          ),
+        ],
+      ),
+    ),
+  ],
+);
+
+String _logoAsset(ServerType serverType) => switch (serverType) {
+  ServerType.jellyfin => SvgPictures.jellyfinLogo,
+  ServerType.emby => SvgPictures.embyLogo,
+};
+
+class _HoverableServer extends StatefulWidget {
+  const _HoverableServer({required this.server});
+
+  final DiscoveredServer server;
+
+  @override
+  State<_HoverableServer> createState() => _HoverableServerState();
+}
+
+class _HoverableServerState extends State<_HoverableServer> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) => MouseRegion(
+    onEnter: (_) => setState(() => _hovered = true),
+    onExit: (_) => setState(() => _hovered = false),
+    child: Container(
+      color: _hovered ? Colors.black12 : Colors.transparent,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: serverSummary(widget.server),
+    ),
+  );
+}
+
+class DiscoveringSpinner extends StatelessWidget {
+  const DiscoveringSpinner({super.key});
+
+  @override
+  Widget build(BuildContext context) => const Center(
+    widthFactor: 1,
+    child: Padding(
+      padding: EdgeInsets.symmetric(horizontal: 8),
+      child: SizedBox.square(
+        dimension: 18,
+        child: CircularProgressIndicator(strokeWidth: 2, color: Colors.black54),
+      ),
+    ),
+  );
+}

--- a/lib/src/presentation/widgets/widgets.dart
+++ b/lib/src/presentation/widgets/widgets.dart
@@ -29,6 +29,7 @@ export 'rail_collapse_animation.dart';
 export 'random_queue_button.dart';
 export 'scrollable_page_scaffold.dart';
 export 'search_results_sliver.dart';
+export 'server_url_field.dart';
 export 'search_songs_sliver.dart';
 export 'shadowed_button.dart';
 export 'shimmer.dart';

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)com.prodigytech.jellybox</string>

--- a/test/data/services/server_discovery_service_test.dart
+++ b/test/data/services/server_discovery_service_test.dart
@@ -1,0 +1,261 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/data/backend/emby/emby_discovery.dart';
+import 'package:jplayer/src/data/backend/jellyfin/jellyfin_discovery.dart';
+import 'package:jplayer/src/data/backend/server_discovery_protocol.dart';
+import 'package:jplayer/src/data/services/server_discovery_service.dart';
+import 'package:jplayer/src/data/services/server_probe_service.dart';
+
+void main() {
+  RawDatagramSocket? fakeServer;
+
+  Future<void> startFakeServer(Map<String, String> replies) async {
+    final socket = await RawDatagramSocket.bind(
+      InternetAddress.loopbackIPv4,
+      0,
+    );
+    fakeServer = socket;
+    socket.listen((event) {
+      if (event != RawSocketEvent.read) return;
+      final datagram = socket.receive();
+      if (datagram == null) return;
+      final reply = replies[utf8.decode(datagram.data)];
+      if (reply == null) return;
+      socket.send(utf8.encode(reply), datagram.address, datagram.port);
+    });
+  }
+
+  List<ServerDiscoveryProtocol> protocolsOnFakePort() => [
+    JellyfinDiscovery(port: fakeServer!.port),
+    EmbyDiscovery(port: fakeServer!.port),
+  ];
+
+  ServerDiscoveryService serviceUnderTest() => ServerDiscoveryService(
+    protocols: protocolsOnFakePort(),
+    targets: [InternetAddress.loopbackIPv4],
+    localAddresses: () async => [InternetAddress.loopbackIPv4],
+  );
+
+  Future<List<ServerAnnouncement>> discover() => serviceUnderTest()
+      .discover(
+        timeout: const Duration(milliseconds: 600),
+        retryInterval: const Duration(milliseconds: 150),
+      )
+      .toList();
+
+  String announcement({
+    required String name,
+    required String id,
+    required String address,
+  }) => jsonEncode({'Address': address, 'Id': id, 'Name': name});
+
+  tearDown(() {
+    fakeServer?.close();
+    fakeServer = null;
+  });
+
+  group('directedBroadcastFor', () {
+    test('- derives the subnet broadcast of an interface address', () {
+      expect(
+        directedBroadcastFor(InternetAddress('192.168.1.118'))?.address,
+        '192.168.1.255',
+      );
+      expect(
+        directedBroadcastFor(InternetAddress('172.20.15.251'))?.address,
+        '172.20.15.255',
+      );
+    });
+
+    test('- has none for the wildcard address', () {
+      expect(directedBroadcastFor(InternetAddress.anyIPv4), isNull);
+    });
+
+    test('- has none for an IPv6 address', () {
+      expect(directedBroadcastFor(InternetAddress('::1')), isNull);
+    });
+  });
+
+  group('ServerDiscoveryService', () {
+    test('- finds a server that answers the Jellyfin probe', () async {
+      await startFakeServer({
+        const JellyfinDiscovery().probe: announcement(
+          name: 'Living Room',
+          id: 'jf-1',
+          address: 'http://192.168.1.10:8096',
+        ),
+      });
+
+      final found = await discover();
+
+      expect(found, hasLength(1));
+      expect(found.single.serverType, ServerType.jellyfin);
+      expect(found.single.name, 'Living Room');
+      expect(found.single.id, 'jf-1');
+      expect(found.single.address, 'http://192.168.1.10:8096');
+    });
+
+    test('- finds a server that answers the Emby probe', () async {
+      await startFakeServer({
+        const EmbyDiscovery().probe: announcement(
+          name: 'Basement',
+          id: 'emby-1',
+          address: 'http://192.168.1.11:8096',
+        ),
+      });
+
+      final found = await discover();
+
+      expect(found, hasLength(1));
+      expect(found.single.serverType, ServerType.emby);
+      expect(found.single.name, 'Basement');
+    });
+
+    test('- reports both server types when both answer', () async {
+      await startFakeServer({
+        const JellyfinDiscovery().probe: announcement(
+          name: 'Jelly',
+          id: 'jf-1',
+          address: 'http://192.168.1.10:8096',
+        ),
+        const EmbyDiscovery().probe: announcement(
+          name: 'Emb',
+          id: 'emby-1',
+          address: 'http://192.168.1.11:8096',
+        ),
+      });
+
+      final found = await discover();
+
+      expect(
+        found.map((server) => server.serverType).toSet(),
+        {ServerType.jellyfin, ServerType.emby},
+      );
+    });
+
+    test('- reports a repeatedly announced server once', () async {
+      await startFakeServer({
+        const JellyfinDiscovery().probe: announcement(
+          name: 'Living Room',
+          id: 'jf-1',
+          address: 'http://192.168.1.10:8096',
+        ),
+      });
+
+      final found = await discover();
+
+      expect(found, hasLength(1));
+    });
+
+    test('- adds the missing scheme to an announced address', () async {
+      await startFakeServer({
+        const JellyfinDiscovery().probe: announcement(
+          name: 'Living Room',
+          id: 'jf-1',
+          address: '192.168.1.10:8096',
+        ),
+      });
+
+      final found = await discover();
+
+      expect(found.single.address, 'http://192.168.1.10:8096');
+    });
+
+    test('- falls back to the sender address when none is announced', () async {
+      await startFakeServer({
+        const JellyfinDiscovery().probe: jsonEncode({
+          'Id': 'jf-1',
+          'Name': 'Living Room',
+        }),
+      });
+
+      final found = await discover();
+
+      expect(found.single.address, 'http://127.0.0.1:8096');
+    });
+
+    test('- ignores replies that are not server announcements', () async {
+      await startFakeServer({
+        const JellyfinDiscovery().probe: 'pong',
+        const EmbyDiscovery().probe: jsonEncode({
+          'Hello': 'there',
+        }),
+      });
+
+      final found = await discover();
+
+      expect(found, isEmpty);
+    });
+
+    test('- survives an interface that cannot reach the target', () async {
+      await startFakeServer(const {});
+      final found =
+          await ServerDiscoveryService(
+                protocols: protocolsOnFakePort(),
+                targets: [InternetAddress('255.255.255.255')],
+                localAddresses: () async => [InternetAddress.loopbackIPv4],
+              )
+              .discover(
+                timeout: const Duration(milliseconds: 400),
+                retryInterval: const Duration(milliseconds: 100),
+              )
+              .toList();
+
+      expect(found, isEmpty);
+    });
+
+    test('- probes the subnet broadcast as well as the limited one', () {
+      final targets = ServerDiscoveryService(protocols: const [])
+          .targetsFor(InternetAddress('192.168.1.118'))
+          .map((target) => target.address);
+
+      expect(targets, ['255.255.255.255', '192.168.1.255']);
+    });
+
+    test('- probes only the given targets when they are overridden', () {
+      final targets = ServerDiscoveryService(
+        protocols: const [],
+        targets: [InternetAddress.loopbackIPv4],
+      ).targetsFor(InternetAddress('192.168.1.118')).map((t) => t.address);
+
+      expect(targets, ['127.0.0.1']);
+    });
+
+    test('- keeps answering when another target is unroutable', () async {
+      await startFakeServer({
+        const JellyfinDiscovery().probe: announcement(
+          name: 'Living Room',
+          id: 'jf-1',
+          address: 'http://192.168.1.10:8096',
+        ),
+      });
+
+      final found =
+          await ServerDiscoveryService(
+                protocols: protocolsOnFakePort(),
+                targets: [
+                  InternetAddress('255.255.255.255'),
+                  InternetAddress.loopbackIPv4,
+                ],
+                localAddresses: () async => [InternetAddress.loopbackIPv4],
+              )
+              .discover(
+                timeout: const Duration(milliseconds: 600),
+                retryInterval: const Duration(milliseconds: 150),
+              )
+              .toList();
+
+      expect(found, hasLength(1));
+      expect(found.single.name, 'Living Room');
+    });
+
+    test('- completes with nothing when no server answers', () async {
+      await startFakeServer(const {});
+
+      final found = await discover();
+
+      expect(found, isEmpty);
+    });
+  });
+}

--- a/test/domain/providers/discovered_servers_provider_test.dart
+++ b/test/domain/providers/discovered_servers_provider_test.dart
@@ -1,0 +1,239 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/data/backend/server_discovery_protocol.dart';
+import 'package:jplayer/src/data/dto/dto.dart';
+import 'package:jplayer/src/data/providers/providers.dart';
+import 'package:jplayer/src/data/services/server_discovery_service.dart';
+import 'package:jplayer/src/data/services/server_probe_service.dart';
+import 'package:jplayer/src/domain/providers/discovered_servers_provider.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../provider_container.dart';
+
+class MockServerDiscoveryService extends Mock
+    implements ServerDiscoveryService {}
+
+class MockServerProbeService extends Mock implements ServerProbeService {}
+
+void main() {
+  late MockServerDiscoveryService mockDiscovery;
+  late MockServerProbeService mockProbe;
+
+  ServerAnnouncement announcement({
+    String id = 'jf-1',
+    String address = 'http://192.168.1.10:8096',
+    ServerType serverType = ServerType.jellyfin,
+    String? name = 'Announced',
+    String? sourceAddress,
+  }) => ServerAnnouncement(
+    id: id,
+    address: address,
+    serverType: serverType,
+    name: name,
+    sourceAddress: sourceAddress,
+  );
+
+  ServerProbeResult probeResult({
+    String serverUrl = 'http://192.168.1.10:8096',
+    ServerType serverType = ServerType.jellyfin,
+    String? serverName = 'Living Room',
+  }) => ServerProbeResult(
+    serverUrl: serverUrl,
+    serverType: serverType,
+    info: PublicSystemInfoDTO(
+      id: 'server-id',
+      serverName: serverName,
+      version: '10.9.11',
+    ),
+  );
+
+  void announces(List<ServerAnnouncement> announcements) {
+    when(() => mockDiscovery.discover()).thenAnswer(
+      (_) => Stream.fromIterable(announcements),
+    );
+  }
+
+  ServerDiscoveryNotifier notifierUnderTest() {
+    final container = createProviderContainer(
+      overrides: [
+        serverDiscoveryServiceProvider.overrideWithValue(mockDiscovery),
+        serverProbeServiceProvider.overrideWithValue(mockProbe),
+      ],
+    )..listen(serverDiscoveryProvider, (_, _) {});
+    return container.read(serverDiscoveryProvider.notifier);
+  }
+
+  setUp(() {
+    mockDiscovery = MockServerDiscoveryService();
+    mockProbe = MockServerProbeService();
+    announces(const []);
+    when(() => mockProbe.discover(any())).thenAnswer((_) async => null);
+  });
+
+  group('ServerDiscoveryNotifier', () {
+    test('- starts idle', () {
+      final notifier = notifierUnderTest();
+
+      expect(notifier.state.scanning, isFalse);
+      expect(notifier.state.finished, isFalse);
+      expect(notifier.state.servers, isEmpty);
+    });
+
+    test('- finishes empty when nothing answers', () async {
+      final notifier = notifierUnderTest();
+
+      await notifier.scan();
+
+      expect(notifier.state.scanning, isFalse);
+      expect(notifier.state.foundNothing, isTrue);
+    });
+
+    test('- keeps only announcements the probe confirms', () async {
+      announces([
+        announcement(),
+        announcement(id: 'jf-2', address: 'http://192.168.1.99:8096'),
+      ]);
+      when(
+        () => mockProbe.discover('http://192.168.1.10:8096'),
+      ).thenAnswer((_) async => probeResult());
+
+      final notifier = notifierUnderTest();
+      await notifier.scan();
+
+      expect(notifier.state.servers, hasLength(1));
+      expect(
+        notifier.state.servers.single.serverUrl,
+        'http://192.168.1.10:8096',
+      );
+      expect(notifier.state.finished, isTrue);
+    });
+
+    test('- takes the url and type the probe resolved', () async {
+      announces([announcement(address: 'http://192.168.1.11:8096')]);
+      when(() => mockProbe.discover(any())).thenAnswer(
+        (_) async => probeResult(
+          serverUrl: 'http://192.168.1.11:8096/emby',
+          serverType: ServerType.emby,
+        ),
+      );
+
+      final notifier = notifierUnderTest();
+      await notifier.scan();
+
+      final server = notifier.state.servers.single;
+      expect(server.serverUrl, 'http://192.168.1.11:8096/emby');
+      expect(server.serverType, ServerType.emby);
+    });
+
+    test('- names the server after the system info', () async {
+      announces([announcement()]);
+      when(
+        () => mockProbe.discover(any()),
+      ).thenAnswer((_) async => probeResult());
+
+      final notifier = notifierUnderTest();
+      await notifier.scan();
+
+      expect(notifier.state.servers.single.name, 'Living Room');
+    });
+
+    test('- falls back to the announced name', () async {
+      announces([announcement()]);
+      when(
+        () => mockProbe.discover(any()),
+      ).thenAnswer((_) async => probeResult(serverName: null));
+
+      final notifier = notifierUnderTest();
+      await notifier.scan();
+
+      expect(notifier.state.servers.single.name, 'Announced');
+    });
+
+    test('- falls back to the host when nothing is named', () async {
+      announces([announcement(name: null)]);
+      when(
+        () => mockProbe.discover(any()),
+      ).thenAnswer((_) async => probeResult(serverName: null));
+
+      final notifier = notifierUnderTest();
+      await notifier.scan();
+
+      expect(notifier.state.servers.single.name, '192.168.1.10');
+    });
+
+    test('- lists a server reachable at one url once', () async {
+      announces([
+        announcement(),
+        announcement(id: 'jf-1-again', address: 'http://jelly.local:8096'),
+      ]);
+      when(
+        () => mockProbe.discover(any()),
+      ).thenAnswer((_) async => probeResult());
+
+      final notifier = notifierUnderTest();
+      await notifier.scan();
+
+      expect(notifier.state.servers, hasLength(1));
+    });
+
+    test('- falls back to the sender when the announced url is dead', () async {
+      announces([
+        announcement(
+          address: 'http://172.19.0.13:8096',
+          sourceAddress: 'http://192.168.1.118:8096',
+        ),
+      ]);
+      when(
+        () => mockProbe.discover('http://172.19.0.13:8096'),
+      ).thenAnswer((_) async => null);
+      when(() => mockProbe.discover('http://192.168.1.118:8096')).thenAnswer(
+        (_) async => probeResult(serverUrl: 'http://192.168.1.118:8096'),
+      );
+
+      final notifier = notifierUnderTest();
+      await notifier.scan();
+
+      expect(
+        notifier.state.servers.single.serverUrl,
+        'http://192.168.1.118:8096',
+      );
+    });
+
+    test('- lists nothing when neither url answers', () async {
+      announces([
+        announcement(
+          address: 'http://172.19.0.13:8096',
+          sourceAddress: 'http://192.168.1.118:8096',
+        ),
+      ]);
+
+      final notifier = notifierUnderTest();
+      await notifier.scan();
+
+      expect(notifier.state.servers, isEmpty);
+      expect(notifier.state.foundNothing, isTrue);
+    });
+
+    test('- drops the results of a scan that was restarted', () async {
+      final firstScan = StreamController<ServerAnnouncement>();
+      when(() => mockDiscovery.discover()).thenAnswer((_) => firstScan.stream);
+      when(
+        () => mockProbe.discover(any()),
+      ).thenAnswer((_) async => probeResult());
+
+      final notifier = notifierUnderTest();
+      final pending = notifier.scan();
+
+      announces(const []);
+      await notifier.scan();
+      firstScan
+        ..add(announcement())
+        ..close().ignore();
+      await pending;
+
+      expect(notifier.state.servers, isEmpty);
+      expect(notifier.state.finished, isTrue);
+    });
+  });
+}

--- a/test/domain/providers/download_manager_provider_test.dart
+++ b/test/domain/providers/download_manager_provider_test.dart
@@ -182,6 +182,9 @@ void main() {
             files: any(named: 'files'),
           ),
         ).thenAnswer((_) async => faker.datatype.number());
+        when(
+          () => mockDownloadService.downloadAlbumCover(any(), any()),
+        ).thenAnswer((_) async => FakeFile());
         providerContainer.listen(
           downloadManagerProvider,
           mockListener.call,

--- a/test/presentation/pages/login_page_test.dart
+++ b/test/presentation/pages/login_page_test.dart
@@ -1,11 +1,17 @@
+import 'dart:async';
+
 import 'package:faker_dart/faker_dart.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/data/backend/server_discovery_protocol.dart';
 import 'package:jplayer/src/data/dto/dto.dart';
 import 'package:jplayer/src/data/params/params.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
+import 'package:jplayer/src/data/services/server_discovery_service.dart';
 import 'package:jplayer/src/data/services/server_probe_service.dart';
+import 'package:jplayer/src/domain/providers/discovered_servers_provider.dart';
 import 'package:jplayer/src/presentation/pages/login_page.dart';
 import 'package:jplayer/src/presentation/widgets/widgets.dart';
 import 'package:jplayer/src/providers/auth_provider.dart';
@@ -20,6 +26,9 @@ class MockAuthNotifier extends AsyncNotifier<bool?>
 
 class MockServerProbeService extends Mock implements ServerProbeService {}
 
+class MockServerDiscoveryService extends Mock
+    implements ServerDiscoveryService {}
+
 class FakeUserCredentials extends Fake implements UserCredentials {}
 
 void main() {
@@ -27,6 +36,7 @@ void main() {
 
   late AuthNotifier mockAuthNotifier;
   late MockServerProbeService mockProbeService;
+  late MockServerDiscoveryService mockDiscoveryService;
 
   final faker = Faker.instance;
 
@@ -35,6 +45,7 @@ void main() {
       overrides: [
         authProvider.overrideWith(() => mockAuthNotifier),
         serverProbeServiceProvider.overrideWithValue(mockProbeService),
+        serverDiscoveryServiceProvider.overrideWithValue(mockDiscoveryService),
       ],
     ),
     home: const LoginPage(),
@@ -43,15 +54,56 @@ void main() {
   ServerProbeResult discoveryResult(
     String serverUrl, {
     ServerType serverType = ServerType.jellyfin,
+    String serverName = 'Living Room',
   }) => ServerProbeResult(
     serverUrl: serverUrl,
     serverType: serverType,
-    info: const PublicSystemInfoDTO(
+    info: PublicSystemInfoDTO(
       id: 'server-id',
-      serverName: 'Living Room',
+      serverName: serverName,
       version: '10.9.11',
     ),
   );
+
+  void announcesServers(List<ServerAnnouncement> announcements) {
+    when(
+      () => mockDiscoveryService.discover(),
+    ).thenAnswer((_) => Stream.fromIterable(announcements));
+  }
+
+  StreamController<ServerAnnouncement> announcesSlowly() {
+    final controller = StreamController<ServerAnnouncement>();
+    addTearDown(() => controller.close().ignore());
+    when(
+      () => mockDiscoveryService.discover(),
+    ).thenAnswer((_) => controller.stream);
+    return controller;
+  }
+
+  void findsServerAt(
+    String url, {
+    String name = 'Living Room',
+    ServerType type = ServerType.jellyfin,
+  }) {
+    when(() => mockProbeService.discover(url)).thenAnswer(
+      (_) async => discoveryResult(url, serverType: type, serverName: name),
+    );
+  }
+
+  ServerAnnouncement announcement({
+    required String address,
+    ServerType serverType = ServerType.jellyfin,
+  }) => ServerAnnouncement(
+    id: address,
+    address: address,
+    serverType: serverType,
+    name: 'Announced',
+  );
+
+  String serverUrlFieldText(WidgetTester widgetTester) => widgetTester
+      .widget<EditableText>(find.byType(EditableText).first)
+      .controller
+      .text;
 
   Future<void> enterServerUrlAndUnfocus(
     WidgetTester widgetTester,
@@ -73,6 +125,8 @@ void main() {
   setUp(() {
     mockAuthNotifier = MockAuthNotifier();
     mockProbeService = MockServerProbeService();
+    mockDiscoveryService = MockServerDiscoveryService();
+    announcesServers(const []);
     when(mockAuthNotifier.build).thenAnswer((_) async => true);
     when(() => mockAuthNotifier.login(any())).thenAnswer((_) async => null);
     when(() => mockProbeService.discover(any())).thenAnswer((_) async => null);
@@ -269,6 +323,297 @@ void main() {
 
         expect(find.text('Discovered: Jellyfin server'), findsNothing);
         expect(find.byIcon(Icons.check_circle), findsNothing);
+      },
+    );
+
+    testWidgets(
+      '- shows the auto discovering placeholder while scanning',
+      (widgetTester) async {
+        announcesSlowly();
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pump(Duration.zero);
+
+        expect(
+          find.text(ServerUrlField.discoveringPlaceholder),
+          findsOneWidget,
+        );
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      '- drops discovery for good once the user types',
+      (widgetTester) async {
+        final discovery = announcesSlowly();
+        findsServerAt('http://192.168.1.10:8096');
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pump(Duration.zero);
+        await widgetTester.enterText(
+          find.widgetWithText(LabeledTextField, 'Server URL'),
+          'my.server',
+        );
+        await widgetTester.pump();
+
+        expect(find.text(ServerUrlField.discoveringPlaceholder), findsNothing);
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+
+        discovery.add(announcement(address: 'http://192.168.1.10:8096'));
+        await widgetTester.pumpAndSettle();
+
+        expect(find.text('Living Room'), findsNothing);
+        expect(serverUrlFieldText(widgetTester), 'my.server');
+      },
+    );
+
+    testWidgets(
+      '- replaces the field with the server that was found',
+      (widgetTester) async {
+        announcesServers([announcement(address: 'http://192.168.1.10:8096')]);
+        findsServerAt('http://192.168.1.10:8096');
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pumpAndSettle();
+
+        expect(find.text('Living Room'), findsOneWidget);
+        expect(find.text('http://192.168.1.10:8096'), findsOneWidget);
+        expect(find.byIcon(Icons.edit), findsOneWidget);
+        expect(find.byIcon(Icons.keyboard_arrow_down), findsNothing);
+      },
+    );
+
+    testWidgets(
+      '- the pencil turns the found server into an editable field',
+      (widgetTester) async {
+        announcesServers([announcement(address: 'http://192.168.1.10:8096')]);
+        findsServerAt('http://192.168.1.10:8096');
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pumpAndSettle();
+        await widgetTester.tap(find.byIcon(Icons.edit));
+        await widgetTester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.edit), findsNothing);
+        expect(
+          find.widgetWithText(LabeledTextField, 'Server URL'),
+          findsOneWidget,
+        );
+        expect(serverUrlFieldText(widgetTester), 'http://192.168.1.10:8096');
+      },
+    );
+
+    testWidgets(
+      '- offers a dropdown when more than one server is found',
+      (widgetTester) async {
+        announcesServers([
+          announcement(address: 'http://192.168.1.10:8096'),
+          announcement(address: 'http://192.168.1.11:8096'),
+        ]);
+        findsServerAt('http://192.168.1.10:8096');
+        findsServerAt(
+          'http://192.168.1.11:8096',
+          name: 'Basement',
+          type: ServerType.emby,
+        );
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.keyboard_arrow_down), findsOneWidget);
+        expect(find.text('Basement'), findsNothing);
+
+        await widgetTester.tap(find.text('Living Room'));
+        await widgetTester.pumpAndSettle();
+        expect(find.text('Basement'), findsOneWidget);
+
+        await widgetTester.tap(find.text('Basement'));
+        await widgetTester.pumpAndSettle();
+
+        expect(find.text('Basement'), findsOneWidget);
+        expect(find.text('http://192.168.1.11:8096'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      '- keeps the spinner while more servers may still arrive',
+      (widgetTester) async {
+        final discovery = announcesSlowly();
+        findsServerAt('http://192.168.1.10:8096');
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pump(Duration.zero);
+        discovery.add(announcement(address: 'http://192.168.1.10:8096'));
+        await widgetTester.pump();
+        await widgetTester.pump(const Duration(milliseconds: 50));
+
+        expect(find.text('Living Room'), findsOneWidget);
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+        await discovery.close();
+        await widgetTester.pump(const Duration(milliseconds: 100));
+
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+      },
+    );
+
+    testWidgets(
+      '- squares off the bottom of the field while the dropdown is open',
+      (widgetTester) async {
+        announcesServers([
+          announcement(address: 'http://192.168.1.10:8096'),
+          announcement(address: 'http://192.168.1.11:8096'),
+        ]);
+        findsServerAt('http://192.168.1.10:8096');
+        findsServerAt('http://192.168.1.11:8096', name: 'Basement');
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pumpAndSettle();
+
+        BorderRadius surfaceRadius() =>
+            widgetTester
+                    .widget<Material>(find.byKey(ServerUrlField.surfaceKey))
+                    .borderRadius!
+                as BorderRadius;
+
+        expect(surfaceRadius().bottomLeft.x, ServerUrlField.radius);
+
+        await widgetTester.tap(find.text('Living Room'));
+        await widgetTester.pumpAndSettle();
+
+        expect(surfaceRadius().bottomLeft.x, 0);
+        expect(surfaceRadius().topLeft.x, ServerUrlField.radius);
+
+        await widgetTester.tap(find.text('Basement'));
+        await widgetTester.pumpAndSettle();
+
+        expect(surfaceRadius().bottomLeft.x, ServerUrlField.radius);
+      },
+    );
+
+    testWidgets(
+      '- keeps the spinner square',
+      (widgetTester) async {
+        announcesSlowly();
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pump(Duration.zero);
+
+        final size = widgetTester.getSize(
+          find.byType(CircularProgressIndicator),
+        );
+        expect(size.width, size.height);
+      },
+    );
+
+    testWidgets(
+      '- highlights the dropdown row under the pointer',
+      (widgetTester) async {
+        announcesServers([
+          announcement(address: 'http://192.168.1.10:8096'),
+          announcement(address: 'http://192.168.1.11:8096'),
+        ]);
+        findsServerAt('http://192.168.1.10:8096');
+        findsServerAt('http://192.168.1.11:8096', name: 'Basement');
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pumpAndSettle();
+        await widgetTester.tap(find.text('Living Room'));
+        await widgetTester.pumpAndSettle();
+
+        Color? rowColor() => widgetTester
+            .widget<Container>(
+              find
+                  .ancestor(
+                    of: find.text('Basement'),
+                    matching: find.byType(Container),
+                  )
+                  .first,
+            )
+            .color;
+
+        expect(rowColor(), Colors.transparent);
+
+        final pointer = await widgetTester.createGesture(
+          kind: PointerDeviceKind.mouse,
+        );
+        await pointer.addPointer(location: Offset.zero);
+        addTearDown(pointer.removePointer);
+        await pointer.moveTo(widgetTester.getCenter(find.text('Basement')));
+        await widgetTester.pumpAndSettle();
+
+        expect(rowColor(), isNot(Colors.transparent));
+      },
+    );
+
+    testWidgets(
+      '- opens the dropdown at the full width of the field',
+      (widgetTester) async {
+        announcesServers([
+          announcement(address: 'http://192.168.1.10:8096'),
+          announcement(address: 'http://192.168.1.11:8096'),
+        ]);
+        findsServerAt('http://192.168.1.10:8096');
+        findsServerAt('http://192.168.1.11:8096', name: 'Basement');
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pumpAndSettle();
+        final fieldWidth = widgetTester
+            .getSize(find.byType(ServerUrlField))
+            .width;
+
+        await widgetTester.tap(find.text('Living Room'));
+        await widgetTester.pumpAndSettle();
+
+        final itemWidth = widgetTester
+            .getSize(find.byType(PopupMenuItem<DiscoveredServer>).first)
+            .width;
+        expect(itemWidth, fieldWidth);
+      },
+    );
+
+    testWidgets(
+      '- signs in with the server picked on the network',
+      (widgetTester) async {
+        when(
+          () => mockAuthNotifier.login(any(), serverType: ServerType.emby),
+        ).thenAnswer((_) async => null);
+        announcesServers([
+          announcement(
+            address: 'http://192.168.1.11:8096',
+            serverType: ServerType.emby,
+          ),
+        ]);
+        when(
+          () => mockProbeService.discover('http://192.168.1.11:8096'),
+        ).thenAnswer(
+          (_) async => discoveryResult(
+            'http://192.168.1.11:8096/emby',
+            serverType: ServerType.emby,
+          ),
+        );
+
+        await widgetTester.pumpWidget(getWidgetUT());
+        await widgetTester.pumpAndSettle();
+        await widgetTester.enterText(
+          find.widgetWithText(LabeledTextField, 'Login'),
+          'alex',
+        );
+        final signInFinder = find.widgetWithText(ShadowedButton, 'Sign in');
+        await widgetTester.ensureVisible(signInFinder);
+        await widgetTester.pumpAndSettle();
+        await widgetTester.tap(signInFinder);
+        await widgetTester.pumpAndSettle();
+
+        final credentials =
+            verify(
+                  () => mockAuthNotifier.login(
+                    captureAny(),
+                    serverType: ServerType.emby,
+                  ),
+                ).captured.single
+                as UserCredentials;
+        expect(credentials.serverUrl, 'http://192.168.1.11:8096/emby');
       },
     );
 


### PR DESCRIPTION
This pr adds auto discovery for jellyfin/emby servers using their auto discovery server capabilities.
This feature works in most cases when your server visible in your network not on http port but also on udp ports(depending on configuration). That means in order to get auto discovery to work - your docker container should expose udp ports too

This also doesnt really work when you connected via VPNs or other tunnels, because of those VPN and tunnel limitations and there isnt much I can do about it from app side

<img width="1280" height="720" alt="output" src="https://github.com/user-attachments/assets/0ee4270f-cae9-4fdc-99a3-c4a4b77dc2a2" />
