### PR TITLE
Forward caching

### DIFF
--- a/assets/db/migrations/queue_cache_v6.sql
+++ b/assets/db/migrations/queue_cache_v6.sql
@@ -1,0 +1,10 @@
+CREATE TABLE QueueCache (
+    Id TEXT NOT NULL,
+    ServerId TEXT NOT NULL DEFAULT '',
+    FilePath TEXT NOT NULL,
+    SizeInBytes INTEGER NOT NULL,
+    CachedDate INTEGER NOT NULL,
+    LastUsedDate INTEGER NOT NULL,
+    Data TEXT NOT NULL,
+    PRIMARY KEY (Id, ServerId)
+)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:flutter_udid/flutter_udid.dart';
 import 'package:jplayer/src/app.dart';
 import 'package:jplayer/src/core/carplay/carplay_handler.dart';
 import 'package:jplayer/src/core/downloads/download_paths.dart';
+import 'package:jplayer/src/core/errors/image_error_filter.dart';
 import 'package:jplayer/src/data/storages/download_database.dart';
 import 'package:jplayer/src/data/storages/window_size_storage.dart';
 import 'package:jplayer/src/screen_factory.dart';
@@ -142,4 +143,17 @@ Future<void> main() async {
       ),
     ),
   );
+
+  _silenceUnreachableImageErrors();
+}
+
+void _silenceUnreachableImageErrors() {
+  final reportError = FlutterError.onError;
+  FlutterError.onError = (details) {
+    if (isUnreachableImageFailure(details)) {
+      debugPrint('[Images] unreachable: ${details.exception}');
+      return;
+    }
+    reportError?.call(details);
+  };
 }

--- a/lib/resources/db_migrations.dart
+++ b/lib/resources/db_migrations.dart
@@ -12,6 +12,7 @@ class DbMigrations {
   static const String playlistsV5 = 'assets/db/migrations/playlists_v5.sql';
   static const String playlistSongsV5 =
       'assets/db/migrations/playlist_songs_v5.sql';
+  static const String queueCacheV6 = 'assets/db/migrations/queue_cache_v6.sql';
   static const String generatedPlaylists =
       'assets/db/migrations/generated_playlists.sql';
   static const String generatedPlaylistItems =

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -17,6 +17,7 @@ import 'package:jplayer/src/domain/providers/app_settings_provider.dart';
 import 'package:jplayer/src/domain/providers/current_day_provider.dart';
 import 'package:jplayer/src/domain/providers/current_library_provider.dart';
 import 'package:jplayer/src/domain/providers/current_user_provider.dart';
+import 'package:jplayer/src/domain/providers/forward_cache_provider.dart';
 import 'package:jplayer/src/domain/providers/playback_provider.dart';
 import 'package:jplayer/src/domain/providers/studio_mode_provider.dart';
 import 'package:jplayer/src/presentation/themes/themes.dart';
@@ -252,6 +253,11 @@ class _AppState extends ConsumerState<App> with WidgetsBindingObserver {
                       name: Routes.palette.name,
                       pageBuilder: widget.screenFactory.palettePage,
                     ),
+                    GoRoute(
+                      path: Routes.queueCache.path,
+                      name: Routes.queueCache.name,
+                      pageBuilder: widget.screenFactory.queueCachePage,
+                    ),
                   ],
                 ),
               ],
@@ -310,6 +316,7 @@ class _AppState extends ConsumerState<App> with WidgetsBindingObserver {
           _maybeRestorePlayback();
         }
       })
+      ..listen(forwardCacheProvider, (_, _) {})
       ..listen(castFailureProvider, (previous, next) {
         if (next == null) return;
         _scaffoldMessengerKey.currentState?.showSnackBar(

--- a/lib/src/config/routes.dart
+++ b/lib/src/config/routes.dart
@@ -12,6 +12,7 @@ enum Routes {
   artist('artist'),
   genre('genre'),
   palette('palette'),
+  queueCache('queue-cache'),
   searchResults('search-results'),
   playlist('playlist'),
   favourites('favourites'),

--- a/lib/src/core/audio/queue_shuffle_order.dart
+++ b/lib/src/core/audio/queue_shuffle_order.dart
@@ -14,6 +14,11 @@ class QueueShuffleOrder extends ShuffleOrder {
 
   int get lastPosition => indices.length;
 
+  int? positionOfIndex(int index) {
+    final position = indices.indexOf(index);
+    return position < 0 ? null : position;
+  }
+
   int positionAfterIndex(int index) {
     final position = indices.indexOf(index);
     return position < 0 ? indices.length : position + 1;

--- a/lib/src/core/downloads/cache_downloader.dart
+++ b/lib/src/core/downloads/cache_downloader.dart
@@ -1,0 +1,56 @@
+import 'package:background_downloader/background_downloader.dart' as bd;
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:path/path.dart' as p;
+
+abstract class CacheDownloader {
+  Future<String> directoryPath();
+
+  Future<String?> fetch({
+    required String id,
+    required String url,
+    required String fileName,
+  });
+
+  Future<void> cancel(String id);
+}
+
+class BackgroundCacheDownloader implements CacheDownloader {
+  static const _group = 'queue-cache';
+  static const _directory = 'Caches/queue_cache';
+  static const bd.BaseDirectory _baseDirectory =
+      bd.BaseDirectory.applicationLibrary;
+
+  @visibleForTesting
+  static String taskIdFor(String songId) => 'queue-cache-$songId';
+
+  @override
+  Future<String> directoryPath() async => p.join(
+    await bd.Task.baseDirectoryPath(_baseDirectory),
+    _directory,
+  );
+
+  @override
+  Future<String?> fetch({
+    required String id,
+    required String url,
+    required String fileName,
+  }) async {
+    final task = bd.DownloadTask(
+      taskId: taskIdFor(id),
+      url: url,
+      filename: fileName,
+      directory: _directory,
+      baseDirectory: _baseDirectory,
+      group: _group,
+      retries: 3,
+      priority: 8,
+    );
+    final result = await bd.FileDownloader().download(task);
+    if (result.status != bd.TaskStatus.complete) return null;
+    return task.filePath();
+  }
+
+  @override
+  Future<void> cancel(String id) =>
+      bd.FileDownloader().cancelTasksWithIds([taskIdFor(id)]);
+}

--- a/lib/src/core/downloads/download_paths.dart
+++ b/lib/src/core/downloads/download_paths.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:path_provider/path_provider.dart';
 
 class DownloadPaths {
@@ -10,6 +11,9 @@ class DownloadPaths {
   static String? _root;
 
   static String? get root => _root;
+
+  @visibleForTesting
+  static set root(String? path) => _root = path;
 
   static Future<String> init() async {
     final existing = _root;

--- a/lib/src/core/enums/enums.dart
+++ b/lib/src/core/enums/enums.dart
@@ -1,6 +1,8 @@
 export 'browse_layout.dart';
 export 'download_status.dart';
 export 'entities.dart';
+export 'forward_cache_limit.dart';
+export 'forward_cache_window.dart';
 export 'item_list.dart';
 export 'layout.dart';
 export 'network_exceptions.dart';

--- a/lib/src/core/enums/forward_cache_limit.dart
+++ b/lib/src/core/enums/forward_cache_limit.dart
@@ -1,0 +1,14 @@
+enum ForwardCacheLimit {
+  off(0),
+  mb500(500 * 1024 * 1024),
+  gb1(1024 * 1024 * 1024),
+  gb2(2 * 1024 * 1024 * 1024),
+  gb4(4 * 1024 * 1024 * 1024),
+  gb8(8 * 1024 * 1024 * 1024);
+
+  const ForwardCacheLimit(this.bytes);
+
+  final int bytes;
+
+  bool get isEnabled => bytes > 0;
+}

--- a/lib/src/core/enums/forward_cache_window.dart
+++ b/lib/src/core/enums/forward_cache_window.dart
@@ -1,0 +1,13 @@
+enum ForwardCacheWindow {
+  min10(10),
+  min15(15),
+  min30(30),
+  min45(45),
+  min60(60);
+
+  const ForwardCacheWindow(this.minutes);
+
+  final int minutes;
+
+  Duration get duration => Duration(minutes: minutes);
+}

--- a/lib/src/core/errors/image_error_filter.dart
+++ b/lib/src/core/errors/image_error_filter.dart
@@ -1,0 +1,19 @@
+import 'dart:io' show SocketException;
+
+import 'package:flutter/foundation.dart';
+
+const _imageLibrary = 'image resource service';
+
+bool isUnreachableImageFailure(FlutterErrorDetails details) {
+  if (details.library != _imageLibrary) return false;
+
+  final exception = details.exception;
+  if (exception is SocketException) return true;
+
+  final description = exception.toString();
+  return description.contains('SocketException') ||
+      description.contains('Failed host lookup') ||
+      description.contains('Connection refused') ||
+      description.contains('Connection closed') ||
+      description.contains('Connection timed out');
+}

--- a/lib/src/data/providers/providers.dart
+++ b/lib/src/data/providers/providers.dart
@@ -3,6 +3,8 @@ export 'download_database_provider.dart';
 export 'generated_playlist_database_provider.dart';
 export 'media_server_client_provider.dart';
 export 'playback_storage_provider.dart';
+export 'queue_cache_database_provider.dart';
+export 'queue_cache_service_provider.dart';
 export 'search_provider.dart';
 export 'secure_storage_provider.dart';
 export 'server_discovery_provider.dart';

--- a/lib/src/data/providers/queue_cache_database_provider.dart
+++ b/lib/src/data/providers/queue_cache_database_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jplayer/src/data/providers/download_database_provider.dart';
+import 'package:jplayer/src/data/storages/queue_cache_database.dart';
+
+final queueCacheDatabaseProvider = Provider<QueueCacheDatabase>(
+  (ref) => QueueCacheDatabase(ref.watch(downloadDatabaseProvider)),
+);

--- a/lib/src/data/providers/queue_cache_service_provider.dart
+++ b/lib/src/data/providers/queue_cache_service_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:jplayer/main.dart';
 import 'package:jplayer/src/core/downloads/cache_downloader.dart';
+import 'package:jplayer/src/data/providers/download_database_provider.dart';
 import 'package:jplayer/src/data/providers/queue_cache_database_provider.dart';
 import 'package:jplayer/src/data/services/queue_cache_service.dart';
 
@@ -11,6 +12,7 @@ final cacheDownloaderProvider = Provider<CacheDownloader>(
 final queueCacheServiceProvider = Provider<QueueCacheService>(
   (ref) => QueueCacheService(
     database: ref.watch(queueCacheDatabaseProvider),
+    downloads: ref.watch(downloadDatabaseProvider),
     downloader: ref.watch(cacheDownloaderProvider),
     deviceId: deviceId,
   ),

--- a/lib/src/data/providers/queue_cache_service_provider.dart
+++ b/lib/src/data/providers/queue_cache_service_provider.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jplayer/main.dart';
+import 'package:jplayer/src/core/downloads/cache_downloader.dart';
+import 'package:jplayer/src/data/providers/queue_cache_database_provider.dart';
+import 'package:jplayer/src/data/services/queue_cache_service.dart';
+
+final cacheDownloaderProvider = Provider<CacheDownloader>(
+  (ref) => BackgroundCacheDownloader(),
+);
+
+final queueCacheServiceProvider = Provider<QueueCacheService>(
+  (ref) => QueueCacheService(
+    database: ref.watch(queueCacheDatabaseProvider),
+    downloader: ref.watch(cacheDownloaderProvider),
+    deviceId: deviceId,
+  ),
+);

--- a/lib/src/data/services/album_cover_store.dart
+++ b/lib/src/data/services/album_cover_store.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:jplayer/src/core/downloads/download_paths.dart';
+
+typedef CoverFetcher = Future<List<int>?> Function(Uri uri);
+
+class AlbumCoverStore {
+  AlbumCoverStore({CoverFetcher? fetch}) : _fetch = fetch ?? _fetchOverHttp;
+
+  final CoverFetcher _fetch;
+
+  Future<File?> ensure(String albumId, Uri? uri) async {
+    if (uri == null) return null;
+    await DownloadPaths.init();
+    final path = DownloadPaths.coverPath(albumId);
+    if (path == null) return null;
+
+    final file = File(path);
+    if (file.existsSync() && file.lengthSync() > 0) return file;
+
+    try {
+      final bytes = await _fetch(uri);
+      if (bytes == null || bytes.isEmpty) return null;
+      await file.parent.create(recursive: true);
+      await file.writeAsBytes(bytes);
+      return file;
+    } on Object catch (error) {
+      debugPrint('[Covers] cover for $albumId failed: $error');
+      if (file.existsSync()) await file.delete();
+      return null;
+    }
+  }
+
+  Future<void> sweepUnreferenced(Set<String> keepAlbumIds) async {
+    final root = DownloadPaths.root;
+    if (root == null) return;
+    final directory = Directory(root);
+    if (!directory.existsSync()) return;
+
+    for (final entry in directory.listSync().whereType<Directory>()) {
+      final albumId = entry.path.split(Platform.pathSeparator).last;
+      if (keepAlbumIds.contains(albumId)) continue;
+      final contents = entry.listSync().whereType<File>().toList();
+      if (contents.isEmpty) continue;
+      final onlyCover = contents.every(
+        (file) =>
+            file.path.split(Platform.pathSeparator).last ==
+            DownloadPaths.coverFileName,
+      );
+      if (onlyCover) await entry.delete(recursive: true);
+    }
+  }
+
+  static Future<List<int>?> _fetchOverHttp(Uri uri) async {
+    final client = HttpClient();
+    try {
+      final response = await (await client.getUrl(uri)).close();
+      if (response.statusCode != HttpStatus.ok) {
+        await response.drain<void>();
+        return null;
+      }
+      final chunks = await response.toList();
+      return [for (final chunk in chunks) ...chunk];
+    } finally {
+      client.close(force: true);
+    }
+  }
+}

--- a/lib/src/data/services/download_service.dart
+++ b/lib/src/data/services/download_service.dart
@@ -7,10 +7,12 @@ import 'package:jplayer/src/core/audio/stream_target_profile.dart';
 import 'package:jplayer/src/core/downloads/download_paths.dart';
 import 'package:jplayer/src/core/enums/download_status.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
+import 'package:jplayer/src/data/services/album_cover_store.dart';
 import 'package:jplayer/src/domain/models/models.dart';
 import 'package:path_provider/path_provider.dart';
 
 class DownloadService extends ChangeNotifier {
+  final _covers = AlbumCoverStore();
   final _tasks = <String, DownloadTask>{};
   final _bdTasks = <String, bd.DownloadTask>{};
 
@@ -117,33 +119,8 @@ class DownloadService extends ChangeNotifier {
     }
   }
 
-  Future<File?> downloadAlbumCover(String albumId, Uri? uri) async {
-    if (uri == null) return null;
-    await DownloadPaths.init();
-    final path = DownloadPaths.coverPath(albumId);
-    if (path == null) return null;
-
-    final file = File(path);
-    if (file.existsSync() && file.lengthSync() > 0) return file;
-
-    final httpClient = HttpClient();
-    try {
-      final response = await (await httpClient.getUrl(uri)).close();
-      if (response.statusCode != HttpStatus.ok) {
-        await response.drain<void>();
-        return null;
-      }
-      await file.parent.create(recursive: true);
-      await response.pipe(file.openWrite());
-      return file;
-    } on Object catch (error) {
-      debugPrint('[Download] cover for $albumId failed: $error');
-      if (file.existsSync()) await file.delete();
-      return null;
-    } finally {
-      httpClient.close(force: true);
-    }
-  }
+  Future<File?> downloadAlbumCover(String albumId, Uri? uri) =>
+      _covers.ensure(albumId, uri);
 
   Future<void> pauseDownload(String id) async {
     final bdTask = _bdTasks[id];

--- a/lib/src/data/services/queue_cache_service.dart
+++ b/lib/src/data/services/queue_cache_service.dart
@@ -1,0 +1,132 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:jplayer/src/core/audio/stream_target_profile.dart';
+import 'package:jplayer/src/core/downloads/cache_downloader.dart';
+import 'package:jplayer/src/data/backend/media_server_client.dart';
+import 'package:jplayer/src/data/backend/stream_source.dart';
+import 'package:jplayer/src/data/services/album_cover_store.dart';
+import 'package:jplayer/src/data/storages/queue_cache_database.dart';
+import 'package:jplayer/src/domain/models/models.dart';
+
+class QueueCacheService {
+  QueueCacheService({
+    required QueueCacheDatabase database,
+    required CacheDownloader downloader,
+    required String deviceId,
+    AlbumCoverStore? covers,
+  }) : _database = database,
+       _downloader = downloader,
+       _deviceId = deviceId,
+       _covers = covers ?? AlbumCoverStore();
+
+  static const _coverSize = 512;
+
+  final QueueCacheDatabase _database;
+  final CacheDownloader _downloader;
+  final String _deviceId;
+  final AlbumCoverStore _covers;
+
+  Future<String?> cache(LibraryItem song, MediaServerClient client) async {
+    try {
+      final resolved = await client.resolveStreamSource(
+        song,
+        playSessionId: 'cache-$_deviceId-${song.id}',
+        target: StreamTargetProfile.download(),
+      );
+      final path = await _downloader.fetch(
+        id: song.id,
+        url: resolved.uri.toString(),
+        fileName: '${song.id}.${resolved.outputContainer}',
+      );
+      if (path == null) return null;
+      final file = File(path);
+      if (!file.existsSync() || file.lengthSync() == 0) {
+        if (file.existsSync()) await file.delete();
+        return null;
+      }
+      await _database.insert(song, file: file);
+      await _cacheCover(song, client);
+      debugPrint('[QueueCache] cached "${song.name}"');
+      return path;
+    } on Object catch (error) {
+      debugPrint('[QueueCache] "${song.name}" failed: $error');
+      return null;
+    }
+  }
+
+  Future<void> _cacheCover(LibraryItem song, MediaServerClient client) async {
+    final albumId = song.albumId;
+    if (albumId == null) return;
+    try {
+      await _covers.ensure(
+        albumId,
+        client.imageUri(song, kind: ImageKind.album, size: _coverSize),
+      );
+    } on Object catch (error) {
+      debugPrint('[QueueCache] cover for "${song.name}" failed: $error');
+    }
+  }
+
+  Future<void> cancel(String id) async {
+    try {
+      await _downloader.cancel(id);
+    } on Object catch (error) {
+      debugPrint('[QueueCache] cancelling $id failed: $error');
+    }
+  }
+
+  Future<void> enforceLimit(
+    int limitBytes, {
+    Set<String> keepIds = const {},
+  }) async {
+    var used = await _database.totalBytes();
+    if (used <= limitBytes) return;
+    for (final entry in await _database.leastRecentlyUsed(
+      excludedIds: keepIds,
+    )) {
+      if (used <= limitBytes) break;
+      await _database.delete(entry.id);
+      used -= entry.sizeInBytes;
+    }
+  }
+
+  Future<void> purge() async {
+    await _database.deleteAll();
+    await _deleteOrphanFiles();
+  }
+
+  Future<void> reconcile() async {
+    await _database.deleteForeignServers();
+    await _database.pruneMissing();
+    await _deleteOrphanFiles();
+    await _sweepCovers();
+  }
+
+  Future<void> _sweepCovers() async {
+    try {
+      final entries = await _database.detailedEntries();
+      await _covers.sweepUnreferenced({
+        for (final entry in entries)
+          if (entry.item.albumId case final String albumId) albumId,
+      });
+    } on Object catch (error) {
+      debugPrint('[QueueCache] sweeping covers failed: $error');
+    }
+  }
+
+  Future<int> pruneMissing() => _database.pruneMissing();
+
+  Future<void> _deleteOrphanFiles() async {
+    try {
+      final directory = Directory(await _downloader.directoryPath());
+      if (!directory.existsSync()) return;
+      final known = await _database.allFilePaths();
+      for (final file in directory.listSync().whereType<File>()) {
+        if (!known.contains(file.path)) await file.delete();
+      }
+    } on Object catch (error) {
+      debugPrint('[QueueCache] sweeping stray files failed: $error');
+    }
+  }
+}

--- a/lib/src/data/services/queue_cache_service.dart
+++ b/lib/src/data/services/queue_cache_service.dart
@@ -6,16 +6,19 @@ import 'package:jplayer/src/core/downloads/cache_downloader.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
 import 'package:jplayer/src/data/backend/stream_source.dart';
 import 'package:jplayer/src/data/services/album_cover_store.dart';
+import 'package:jplayer/src/data/storages/download_database.dart';
 import 'package:jplayer/src/data/storages/queue_cache_database.dart';
 import 'package:jplayer/src/domain/models/models.dart';
 
 class QueueCacheService {
   QueueCacheService({
     required QueueCacheDatabase database,
+    required DownloadDatabase downloads,
     required CacheDownloader downloader,
     required String deviceId,
     AlbumCoverStore? covers,
   }) : _database = database,
+       _downloads = downloads,
        _downloader = downloader,
        _deviceId = deviceId,
        _covers = covers ?? AlbumCoverStore();
@@ -23,6 +26,7 @@ class QueueCacheService {
   static const _coverSize = 512;
 
   final QueueCacheDatabase _database;
+  final DownloadDatabase _downloads;
   final CacheDownloader _downloader;
   final String _deviceId;
   final AlbumCoverStore _covers;
@@ -109,6 +113,7 @@ class QueueCacheService {
       await _covers.sweepUnreferenced({
         for (final entry in entries)
           if (entry.item.albumId case final String albumId) albumId,
+        ...await _downloads.downloadedAlbumIds(),
       });
     } on Object catch (error) {
       debugPrint('[QueueCache] sweeping covers failed: $error');

--- a/lib/src/data/storages/download_database.dart
+++ b/lib/src/data/storages/download_database.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io' show Directory, File, FileSystemException;
+import 'dart:math' show min;
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -15,7 +16,7 @@ class DownloadDatabase {
     @visibleForTesting Database? db,
   }) : _db = db;
 
-  static const _schemaVersion = 5;
+  static const _schemaVersion = 6;
 
   static String? databaseDirectory;
 
@@ -77,6 +78,7 @@ class DownloadDatabase {
     await Future.wait(queries.map(db.execute));
     await _migrateToV4(db);
     await _migrateToV5(db);
+    await _migrateToV6(db);
   }
 
   Future<void> _upgradeDB(Database db, int oldVersion, int newVersion) async {
@@ -84,6 +86,11 @@ class DownloadDatabase {
     if (oldVersion < 3) await _migrateToV3(db);
     if (oldVersion < 4) await _migrateToV4(db);
     if (oldVersion < 5) await _migrateToV5(db);
+    if (oldVersion < 6) await _migrateToV6(db);
+  }
+
+  Future<void> _migrateToV6(Database db) async {
+    await db.execute(await rootBundle.loadString(DbMigrations.queueCacheV6));
   }
 
   Future<void> _migrateToV5(Database db) async {
@@ -399,6 +406,25 @@ class DownloadDatabase {
       ),
     );
     return count! > 0;
+  }
+
+  Future<Set<String>> downloadedIds(Iterable<String> ids) async {
+    final wanted = ids.toSet().toList();
+    if (wanted.isEmpty) return const {};
+    final db = await database;
+    final found = <String>{};
+    for (var start = 0; start < wanted.length; start += 500) {
+      final chunk = wanted.sublist(start, min(start + 500, wanted.length));
+      final placeholders = List.filled(chunk.length, '?').join(', ');
+      final results = await db.query(
+        'Downloads',
+        columns: ['Id'],
+        where: 'ServerId = ? AND Id IN ($placeholders)',
+        whereArgs: [serverId, ...chunk],
+      );
+      found.addAll(results.map((row) => row['Id']! as String));
+    }
+    return found;
   }
 
   Future<String?> getDownloadedSongPath(String id) async {

--- a/lib/src/data/storages/download_database.dart
+++ b/lib/src/data/storages/download_database.dart
@@ -408,6 +408,21 @@ class DownloadDatabase {
     return count! > 0;
   }
 
+  Future<Set<String>> downloadedAlbumIds() async {
+    final db = await database;
+    final albums = await db.query('Albums', columns: ['Id']);
+    final songs = await db.query(
+      'Downloads',
+      columns: ['AlbumId'],
+      distinct: true,
+      where: 'AlbumId IS NOT NULL',
+    );
+    return {
+      for (final row in albums) row['Id']! as String,
+      for (final row in songs) row['AlbumId']! as String,
+    };
+  }
+
   Future<Set<String>> downloadedIds(Iterable<String> ids) async {
     final wanted = ids.toSet().toList();
     if (wanted.isEmpty) return const {};

--- a/lib/src/data/storages/queue_cache_database.dart
+++ b/lib/src/data/storages/queue_cache_database.dart
@@ -1,0 +1,228 @@
+import 'dart:convert';
+import 'dart:io' show File;
+import 'dart:math' show min;
+
+import 'package:jplayer/src/data/storages/download_database.dart';
+import 'package:jplayer/src/domain/models/models.dart';
+import 'package:sqflite/sqflite.dart';
+
+typedef CacheEntry = ({String id, String filePath, int sizeInBytes});
+
+typedef CacheDetail = ({
+  LibraryItem item,
+  String filePath,
+  int sizeInBytes,
+  DateTime cachedDate,
+  DateTime lastUsedDate,
+  bool onDisk,
+});
+
+class QueueCacheDatabase {
+  QueueCacheDatabase(this._owner);
+
+  static const _table = 'QueueCache';
+  static const _chunkSize = 500;
+
+  final DownloadDatabase _owner;
+
+  Future<Database> get _database => _owner.database;
+
+  String get _serverId => _owner.serverId;
+
+  Future<void> insert(LibraryItem song, {required File file}) async {
+    final db = await _database;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db.insert(_table, {
+      'Id': song.id,
+      'ServerId': _serverId,
+      'FilePath': file.path,
+      'SizeInBytes': file.lengthSync(),
+      'CachedDate': now,
+      'LastUsedDate': now,
+      'Data': jsonEncode(song.toJson()),
+    }, conflictAlgorithm: ConflictAlgorithm.replace);
+  }
+
+  Future<String?> pathOf(String id) async {
+    final db = await _database;
+    final results = await db.query(
+      _table,
+      columns: ['FilePath'],
+      where: 'Id = ? AND ServerId = ?',
+      whereArgs: [id, _serverId],
+    );
+    return results.firstOrNull?['FilePath'] as String?;
+  }
+
+  Future<Map<String, String>> pathsFor(Iterable<String> ids) async {
+    final wanted = ids.toSet().toList();
+    if (wanted.isEmpty) return const {};
+    final db = await _database;
+    final paths = <String, String>{};
+    for (var start = 0; start < wanted.length; start += _chunkSize) {
+      final chunk = wanted.sublist(
+        start,
+        min(start + _chunkSize, wanted.length),
+      );
+      final results = await db.query(
+        _table,
+        columns: ['Id', 'FilePath'],
+        where: 'ServerId = ? AND Id IN (${_placeholders(chunk.length)})',
+        whereArgs: [_serverId, ...chunk],
+      );
+      for (final row in results) {
+        final path = row['FilePath']! as String;
+        if (File(path).existsSync()) paths[row['Id']! as String] = path;
+      }
+    }
+    return paths;
+  }
+
+  Future<Set<String>> cachedIds() async {
+    final db = await _database;
+    final results = await db.query(
+      _table,
+      columns: ['Id'],
+      where: 'ServerId = ?',
+      whereArgs: [_serverId],
+    );
+    return {for (final row in results) row['Id']! as String};
+  }
+
+  Future<void> touch(String id) async {
+    final db = await _database;
+    await db.update(
+      _table,
+      {'LastUsedDate': DateTime.now().millisecondsSinceEpoch},
+      where: 'Id = ? AND ServerId = ?',
+      whereArgs: [id, _serverId],
+    );
+  }
+
+  Future<int> totalBytes() async {
+    final db = await _database;
+    return Sqflite.firstIntValue(
+          await db.rawQuery(
+            'SELECT SUM(SizeInBytes) FROM $_table WHERE ServerId = ?',
+            [_serverId],
+          ),
+        ) ??
+        0;
+  }
+
+  Future<List<CacheEntry>> entries() => _entries(orderBy: 'LastUsedDate DESC');
+
+  Future<List<CacheEntry>> leastRecentlyUsed({
+    Set<String> excludedIds = const {},
+  }) async {
+    final all = await _entries(orderBy: 'LastUsedDate ASC');
+    return [
+      for (final entry in all)
+        if (!excludedIds.contains(entry.id)) entry,
+    ];
+  }
+
+  Future<List<CacheEntry>> _entries({required String orderBy}) async {
+    final db = await _database;
+    final results = await db.query(
+      _table,
+      columns: ['Id', 'FilePath', 'SizeInBytes'],
+      where: 'ServerId = ?',
+      whereArgs: [_serverId],
+      orderBy: orderBy,
+    );
+    return [for (final row in results) _entryFromRow(row)];
+  }
+
+  Future<List<CacheDetail>> detailedEntries() async {
+    final db = await _database;
+    final results = await db.query(
+      _table,
+      where: 'ServerId = ?',
+      whereArgs: [_serverId],
+      orderBy: 'LastUsedDate DESC',
+    );
+    return [
+      for (final row in results)
+        (
+          item: LibraryItem.fromJson(
+            jsonDecode(row['Data']! as String) as Map<String, dynamic>,
+          ),
+          filePath: row['FilePath']! as String,
+          sizeInBytes: row['SizeInBytes']! as int,
+          cachedDate: DateTime.fromMillisecondsSinceEpoch(
+            row['CachedDate']! as int,
+          ),
+          lastUsedDate: DateTime.fromMillisecondsSinceEpoch(
+            row['LastUsedDate']! as int,
+          ),
+          onDisk: File(row['FilePath']! as String).existsSync(),
+        ),
+    ];
+  }
+
+  Future<Set<String>> allFilePaths() async {
+    final db = await _database;
+    final results = await db.query(_table, columns: ['FilePath']);
+    return {for (final row in results) row['FilePath']! as String};
+  }
+
+  Future<int> pruneMissing() async {
+    var removed = 0;
+    for (final entry in await entries()) {
+      if (!File(entry.filePath).existsSync()) {
+        await delete(entry.id);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  Future<void> deleteForeignServers() async {
+    if (_serverId.isEmpty) return;
+    final db = await _database;
+    final results = await db.query(
+      _table,
+      columns: ['FilePath'],
+      where: 'ServerId != ?',
+      whereArgs: [_serverId],
+    );
+    for (final row in results) {
+      final file = File(row['FilePath']! as String);
+      if (file.existsSync()) await file.delete();
+    }
+    await db.delete(_table, where: 'ServerId != ?', whereArgs: [_serverId]);
+  }
+
+  Future<void> delete(String id) async {
+    final db = await _database;
+    final path = await pathOf(id);
+    if (path != null) {
+      final file = File(path);
+      if (file.existsSync()) await file.delete();
+    }
+    await db.delete(
+      _table,
+      where: 'Id = ? AND ServerId = ?',
+      whereArgs: [id, _serverId],
+    );
+  }
+
+  Future<void> deleteAll() async {
+    final db = await _database;
+    for (final entry in await entries()) {
+      final file = File(entry.filePath);
+      if (file.existsSync()) await file.delete();
+    }
+    await db.delete(_table, where: 'ServerId = ?', whereArgs: [_serverId]);
+  }
+
+  static String _placeholders(int count) =>
+      List.filled(count, '?').join(', ');
+}
+
+CacheEntry _entryFromRow(Map<String, Object?> row) => (
+  id: row['Id']! as String,
+  filePath: row['FilePath']! as String,
+  sizeInBytes: row['SizeInBytes']! as int,
+);

--- a/lib/src/domain/playback/local_playback_target.dart
+++ b/lib/src/domain/playback/local_playback_target.dart
@@ -10,7 +10,7 @@ import 'package:jplayer/src/domain/playback/playback_target.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:just_audio_background/just_audio_background.dart';
 
-class LocalPlaybackTarget implements PlaybackTarget {
+class LocalPlaybackTarget implements PlaybackTarget, SwappableQueue {
   LocalPlaybackTarget(this._player) {
     _subscriptions = [
       _player.currentIndexStream.listen((_) => _emit()),
@@ -136,6 +136,14 @@ class LocalPlaybackTarget implements PlaybackTarget {
           ? _shuffleOrder.positionAfterIndex(current)
           : _shuffleOrder.lastPosition;
     }
+    await _player.insertAudioSource(index, _audioSource(track));
+  }
+
+  @override
+  Future<void> replace(int index, TargetTrack track) async {
+    final position = _shuffleOrder.positionOfIndex(index);
+    await _player.removeAudioSourceAt(index);
+    _shuffleOrder.nextInsertPosition = position;
     await _player.insertAudioSource(index, _audioSource(track));
   }
 

--- a/lib/src/domain/playback/playback_target.dart
+++ b/lib/src/domain/playback/playback_target.dart
@@ -120,3 +120,7 @@ abstract class PlaybackTarget {
 
   Future<void> dispose();
 }
+
+mixin SwappableQueue implements PlaybackTarget {
+  Future<void> replace(int index, TargetTrack track);
+}

--- a/lib/src/domain/providers/app_settings_provider.dart
+++ b/lib/src/domain/providers/app_settings_provider.dart
@@ -17,6 +17,8 @@ enum AppSetting {
   defaultStartPage('default_start_page', defaultValue: 'home'),
   browseLayout('browse_layout', defaultValue: 'cards'),
   playerVolume('player_volume', defaultValue: 1.0),
+  forwardCacheLimit('forward_cache_limit', defaultValue: 'off'),
+  forwardCacheWindow('forward_cache_window', defaultValue: 'min30'),
   rendererVolumes('renderer_volumes', defaultValue: <String, double>{});
 
   const AppSetting(this.key, {this.defaultValue = false});
@@ -54,6 +56,24 @@ final browseLayoutProvider = Provider<BrowseLayout>(
         AppSetting.browseLayout,
       )] ??
       BrowseLayout.cards,
+);
+
+final forwardCacheLimitProvider = Provider<ForwardCacheLimit>(
+  (ref) =>
+      ForwardCacheLimit.values.asNameMap()[_asString(
+        ref.watch(appSettingsProvider)[AppSetting.forwardCacheLimit],
+        AppSetting.forwardCacheLimit,
+      )] ??
+      ForwardCacheLimit.off,
+);
+
+final forwardCacheWindowProvider = Provider<ForwardCacheWindow>(
+  (ref) =>
+      ForwardCacheWindow.values.asNameMap()[_asString(
+        ref.watch(appSettingsProvider)[AppSetting.forwardCacheWindow],
+        AppSetting.forwardCacheWindow,
+      )] ??
+      ForwardCacheWindow.min30,
 );
 
 final defaultStartPageProvider = Provider<StartPage>(

--- a/lib/src/domain/providers/forward_cache_provider.dart
+++ b/lib/src/domain/providers/forward_cache_provider.dart
@@ -1,0 +1,331 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jplayer/src/core/enums/enums.dart';
+import 'package:jplayer/src/data/providers/providers.dart';
+import 'package:jplayer/src/data/services/queue_cache_service.dart';
+import 'package:jplayer/src/domain/models/models.dart';
+import 'package:jplayer/src/domain/providers/app_settings_provider.dart';
+import 'package:jplayer/src/domain/providers/playback_provider.dart';
+import 'package:jplayer/src/providers/connectivity_provider.dart';
+
+class ForwardCacheNotifier extends StateNotifier<Set<String>> {
+  ForwardCacheNotifier(this._ref) : super(const {}) {
+    _ref.listen<ForwardCacheLimit>(
+      forwardCacheLimitProvider,
+      (previous, next) {
+        if (previous != next) unawaited(_onLimitChanged(next));
+      },
+    );
+    _ref.listen<ForwardCacheWindow>(forwardCacheWindowProvider, (
+      previous,
+      next,
+    ) {
+      if (previous != next) _schedule();
+    });
+    _ref.listen<PlaybackState>(playbackProvider, _onPlayback);
+    _ref.listen<bool>(isOfflineProvider, (previous, next) {
+      if (previous != next && !next) _schedule();
+    });
+    _schedule();
+  }
+
+  static const _assumedTrackLength = Duration(minutes: 4);
+
+  final Ref _ref;
+  final _inFlight = <String>{};
+  final _failedIds = <String>{};
+
+  late final Future<void> _ready = _bootstrap();
+
+  QueueCacheService? _service;
+  List<String> _lastQueueIds = const [];
+  var _pumping = false;
+  var _dirty = false;
+  var _stopped = false;
+
+  Future<void> _bootstrap() async {
+    if (!mounted) return;
+    try {
+      await _currentService.reconcile();
+      if (!mounted) return;
+      await _applyLimit();
+    } on Object catch (error) {
+      debugPrint('[ForwardCache] bootstrap failed: $error');
+    }
+  }
+
+  QueueCacheService get _currentService {
+    final service = _ref.read(queueCacheServiceProvider);
+    _service = service;
+    return service;
+  }
+
+  void _schedule() {
+    if (_pumping) {
+      _dirty = true;
+      return;
+    }
+    unawaited(_pump());
+  }
+
+  Future<void> _pump() async {
+    if (_pumping) return;
+    _pumping = true;
+    try {
+      await _ready;
+      do {
+        _dirty = false;
+        while (mounted) {
+          final song = await _nextCandidate();
+          if (song == null) break;
+          await _fill(song);
+        }
+      } while (_dirty && mounted);
+    } on Object catch (error) {
+      debugPrint('[ForwardCache] fill loop failed: $error');
+    } finally {
+      _pumping = false;
+    }
+  }
+
+  Future<void> _applyLimit() async {
+    if (!mounted) return;
+    final limit = _ref.read(forwardCacheLimitProvider);
+    await _currentService.enforceLimit(limit.bytes, keepIds: _queueIds());
+    await _refreshState();
+  }
+
+  Future<LibraryItem?> _nextCandidate() async {
+    if (_stopped) return null;
+    final limit = _ref.read(forwardCacheLimitProvider);
+    if (!limit.isEnabled) return null;
+    if (_ref.read(isOfflineProvider)) return null;
+    if (!_ref.read(playbackProvider.notifier).supportsLocalFiles) return null;
+
+    final database = _ref.read(queueCacheDatabaseProvider);
+    final window = _candidates();
+    if (window.isEmpty) return null;
+
+    final present = await database.pathsFor([
+      for (final song in window) song.id,
+    ]);
+    if (!mounted) return null;
+    final pending = [
+      for (final song in window)
+        if (!present.containsKey(song.id) &&
+            !_failedIds.contains(song.id) &&
+            !_inFlight.contains(song.id))
+          song,
+    ];
+    if (pending.isEmpty) return null;
+
+    final downloaded = await _ref
+        .read(downloadDatabaseProvider)
+        .downloadedIds([for (final song in pending) song.id]);
+    if (!mounted) return null;
+    final wanted = [
+      for (final song in pending)
+        if (!downloaded.contains(song.id)) song,
+    ];
+    if (wanted.isEmpty) return null;
+
+    if (!await _makeRoom(limit, window)) return null;
+    return wanted.first;
+  }
+
+  Future<bool> _makeRoom(
+    ForwardCacheLimit limit,
+    List<LibraryItem> window,
+  ) async {
+    final database = _ref.read(queueCacheDatabaseProvider);
+    if (await database.totalBytes() < limit.bytes) return true;
+    if (!mounted) return false;
+
+    await _currentService.pruneMissing();
+    if (!mounted) return false;
+    if (await database.totalBytes() < limit.bytes) return true;
+    if (!mounted) return false;
+
+    await _currentService.enforceLimit(
+      limit.bytes,
+      keepIds: {for (final song in window) song.id},
+    );
+    if (!mounted) return false;
+    await _refreshState();
+    if (!mounted) return false;
+    return await database.totalBytes() < limit.bytes;
+  }
+
+  List<LibraryItem> _candidates() {
+    final playback = _ref.read(playbackProvider);
+    final songs = playback.songs;
+    if (songs.isEmpty) return const [];
+    final current = (playback.currentMediaIndex ?? 0).clamp(0, songs.length - 1);
+    final window = _ref.read(forwardCacheWindowProvider).duration;
+
+    var ahead = _lengthOf(songs[current]) - playback.position;
+    if (ahead.isNegative) ahead = Duration.zero;
+
+    final ordered = <LibraryItem>[];
+    for (var i = current + 1; i < songs.length && ahead < window; i++) {
+      ordered.add(songs[i]);
+      ahead += _lengthOf(songs[i]);
+    }
+    ordered.add(songs[current]);
+
+    final seen = <String>{};
+    return [
+      for (final song in ordered)
+        if (seen.add(song.id)) song,
+    ];
+  }
+
+  Duration _lengthOf(LibraryItem song) =>
+      song.duration > Duration.zero ? song.duration : _assumedTrackLength;
+
+  Future<void> _fill(LibraryItem song) async {
+    final service = _currentService;
+    _inFlight.add(song.id);
+
+    final path = await service.cache(
+      song,
+      _ref.read(mediaServerClientProvider),
+    );
+    _inFlight.remove(song.id);
+    if (!mounted) return;
+
+    if (path == null) {
+      _failedIds.add(song.id);
+      return;
+    }
+
+    await _applyLimit();
+    if (!mounted) return;
+    await _adopt();
+  }
+
+  void _onPlayback(PlaybackState? previous, PlaybackState next) {
+    final queueChanged = _queueChanged(next.songs);
+    final indexChanged = previous?.currentMediaIndex != next.currentMediaIndex;
+    if (!queueChanged && !indexChanged) return;
+
+    if (queueChanged) {
+      _lastQueueIds = [for (final song in next.songs) song.id];
+      unawaited(_cancelStale(_lastQueueIds.toSet()));
+    }
+    _failedIds.clear();
+    unawaited(_onQueueAdvanced(next));
+  }
+
+  bool _queueChanged(List<LibraryItem> songs) {
+    if (_lastQueueIds.length != songs.length) return true;
+    for (var i = 0; i < songs.length; i++) {
+      if (_lastQueueIds[i] != songs[i].id) return true;
+    }
+    return false;
+  }
+
+  Future<void> _onQueueAdvanced(PlaybackState playback) async {
+    final index = playback.currentMediaIndex;
+    final current = index != null
+        ? playback.songs.elementAtOrNull(index)
+        : null;
+    if (current != null) {
+      try {
+        await _ref.read(queueCacheDatabaseProvider).touch(current.id);
+      } on Object catch (error) {
+        debugPrint('[ForwardCache] touch failed: $error');
+      }
+    }
+    if (!mounted) return;
+    try {
+      await _applyLimit();
+    } on Object catch (error) {
+      debugPrint('[ForwardCache] applying limit failed: $error');
+    }
+    if (!mounted) return;
+    if (!_ref.read(forwardCacheLimitProvider).isEnabled) return;
+    await _adopt();
+    if (!mounted) return;
+    _schedule();
+  }
+
+  Future<void> _cancelStale(Set<String> queueIds) async {
+    final stale = _inFlight.where((id) => !queueIds.contains(id)).toList();
+    for (final id in stale) {
+      _inFlight.remove(id);
+      await _service?.cancel(id);
+    }
+  }
+
+  Future<void> _cancelInFlight() async {
+    final pending = _inFlight.toList();
+    _inFlight.clear();
+    for (final id in pending) {
+      await _service?.cancel(id);
+    }
+  }
+
+  Future<void> cancelPending() async {
+    _stopped = true;
+    await _cancelInFlight();
+  }
+
+  Future<void> _onLimitChanged(ForwardCacheLimit limit) async {
+    if (!limit.isEnabled) await _cancelInFlight();
+    if (!mounted) return;
+    try {
+      await _applyLimit();
+    } on Object catch (error) {
+      debugPrint('[ForwardCache] applying limit failed: $error');
+      return;
+    }
+    if (limit.isEnabled) _schedule();
+  }
+
+  Future<void> _adopt() async {
+    if (!mounted) return;
+    final playback = _ref.read(playbackProvider.notifier);
+    if (!playback.supportsLocalFiles) return;
+    final ids = _queueIds();
+    if (ids.isEmpty) return;
+    try {
+      final paths = await _ref.read(queueCacheDatabaseProvider).pathsFor(ids);
+      if (paths.isEmpty || !mounted) return;
+      await playback.adoptCachedFiles(paths);
+    } on Object catch (error) {
+      debugPrint('[ForwardCache] adopting cached files failed: $error');
+    }
+  }
+
+  Future<void> _refreshState() async {
+    if (!mounted) return;
+    final ids = await _ref.read(queueCacheDatabaseProvider).cachedIds();
+    if (mounted) state = ids;
+  }
+
+  Set<String> _queueIds() => {
+    for (final song in _ref.read(playbackProvider).songs) song.id,
+  };
+
+  @override
+  void dispose() {
+    _stopped = true;
+    final service = _service;
+    final pending = _inFlight.toList();
+    _inFlight.clear();
+    if (service != null) {
+      for (final id in pending) {
+        unawaited(service.cancel(id));
+      }
+    }
+    super.dispose();
+  }
+}
+
+final forwardCacheProvider =
+    StateNotifierProvider<ForwardCacheNotifier, Set<String>>(
+      ForwardCacheNotifier.new,
+    );

--- a/lib/src/domain/providers/playback_provider.dart
+++ b/lib/src/domain/providers/playback_provider.dart
@@ -31,6 +31,8 @@ class PlaybackNotifier extends StateNotifier<PlaybackState> {
 
   final Ref _ref;
   final _playSessionIds = <String, String>{};
+  final _localSongIds = <String>{};
+  Future<void> _adoptions = Future<void>.value();
   late PlaybackTarget _target;
   StreamSubscription<TargetPlaybackState>? _targetSubscription;
   TargetPlaybackState _targetState = TargetPlaybackState.idle;
@@ -41,9 +43,12 @@ class PlaybackNotifier extends StateNotifier<PlaybackState> {
   var _preparingQueue = false;
   var _queueEditsInFlight = 0;
   var _fallingBack = false;
+  var _recoveringLostCache = false;
   Timer? _progressTimer;
 
   PlaybackTarget get target => _target;
+
+  bool get supportsLocalFiles => _target.supportsLocalFiles;
 
   LibraryItem? get _reportedSong {
     final index = _reportedIndex;
@@ -53,6 +58,18 @@ class PlaybackNotifier extends StateNotifier<PlaybackState> {
   void _onTargetFailure() {
     if (_target.kind == PlaybackTargetKind.local) {
       if (state.status == PlaybackStatus.error) return;
+      if (_recoveringLostCache) return;
+      final index = state.currentMediaIndex;
+      final song = index != null ? state.songs.elementAtOrNull(index) : null;
+      final album = state.album;
+      if (song != null &&
+          album != null &&
+          _localSongIds.contains(song.id) &&
+          !_ref.read(isOfflineProvider)) {
+        _recoveringLostCache = true;
+        unawaited(_recoverFromLostCache(song, album));
+        return;
+      }
       state = state.copyWith(status: PlaybackStatus.error);
       return;
     }
@@ -60,6 +77,31 @@ class PlaybackNotifier extends StateNotifier<PlaybackState> {
     _fallingBack = true;
     _ref.read(castFailureProvider.notifier).report(_target.name);
     _ref.read(playbackTargetProvider.notifier).useLocal();
+  }
+
+  Future<void> _recoverFromLostCache(
+    LibraryItem song,
+    LibraryItem album,
+  ) async {
+    try {
+      if ((await _cachedPaths([song])).containsKey(song.id)) {
+        state = state.copyWith(status: PlaybackStatus.error);
+        return;
+      }
+      _localSongIds.remove(song.id);
+      try {
+        await _ref.read(queueCacheDatabaseProvider).delete(song.id);
+      } on Object catch (error) {
+        debugPrint('[Playback] dropping a lost cache row failed: $error');
+      }
+      debugPrint('[Playback] "${song.name}" lost its cached file; restreaming');
+      await play(song, state.songs, album, initialPosition: state.position);
+    } on Object catch (error) {
+      debugPrint('[Playback] recovering a lost cached file failed: $error');
+      state = state.copyWith(status: PlaybackStatus.error);
+    } finally {
+      _recoveringLostCache = false;
+    }
   }
 
   void _listenToTarget() {
@@ -317,16 +359,26 @@ class PlaybackNotifier extends StateNotifier<PlaybackState> {
         for (final song in songs) song.id: '$deviceId-$stamp-${song.id}',
       };
 
+      final cachedPaths = await _cachedPaths(songs);
       final resolved = await Future.wait(
-        songs.map((song) => _resolveTrack(song, album, sessionIds[song.id]!)),
+        songs.map(
+          (song) => _resolveTrack(
+            song,
+            album,
+            sessionIds[song.id]!,
+            cachedPath: cachedPaths[song.id],
+          ),
+        ),
       );
 
       final playableSongs = <LibraryItem>[];
       final tracks = <TargetTrack>[];
+      final localIds = <String>{};
       for (final entry in resolved) {
         if (entry == null) continue;
         playableSongs.add(entry.song);
         tracks.add(entry.track);
+        if (entry.track.isLocalFile) localIds.add(entry.song.id);
       }
 
       if (tracks.isEmpty) {
@@ -342,6 +394,9 @@ class PlaybackNotifier extends StateNotifier<PlaybackState> {
       _playSessionIds
         ..clear()
         ..addAll(sessionIds);
+      _localSongIds
+        ..clear()
+        ..addAll(localIds);
       _preparingQueue = true;
       _reportedIndex = null;
 
@@ -402,11 +457,26 @@ class PlaybackNotifier extends StateNotifier<PlaybackState> {
     }
   }
 
+  Future<Map<String, String>> _cachedPaths(List<LibraryItem> songs) async {
+    if (!_target.supportsLocalFiles || songs.isEmpty) {
+      return const <String, String>{};
+    }
+    try {
+      return await _ref
+          .read(queueCacheDatabaseProvider)
+          .pathsFor([for (final song in songs) song.id]);
+    } on Object catch (error) {
+      debugPrint('[Playback] reading cached paths failed: $error');
+      return const <String, String>{};
+    }
+  }
+
   Future<({LibraryItem song, TargetTrack track})?> _resolveTrack(
     LibraryItem song,
     LibraryItem album,
-    String playSessionId,
-  ) async {
+    String playSessionId, {
+    String? cachedPath,
+  }) async {
     final isDownloaded = await _ref
         .read(downloadManagerProvider.notifier)
         .isSongDownloaded(song.id);
@@ -415,15 +485,17 @@ class PlaybackNotifier extends StateNotifier<PlaybackState> {
               .read(downloadDatabaseProvider)
               .getDownloadedSongPath(song.id)
         : null;
+    final localPath =
+        downloadedPath ?? (_target.supportsLocalFiles ? cachedPath : null);
 
-    if (downloadedPath == null && _ref.read(isOfflineProvider)) return null;
+    if (localPath == null && _ref.read(isOfflineProvider)) return null;
 
     Uri uri;
     var isHls = false;
     var transcoded = false;
     var mimeType = 'application/octet-stream';
-    if (downloadedPath != null) {
-      uri = Uri.file(downloadedPath);
+    if (localPath != null) {
+      uri = Uri.file(localPath);
     } else {
       final resolved = await _ref
           .read(mediaServerClientProvider)
@@ -598,8 +670,19 @@ class PlaybackNotifier extends StateNotifier<PlaybackState> {
 
     final stamp = DateTime.now().microsecondsSinceEpoch.toRadixString(16);
     final sessionId = '$deviceId-$stamp-${song.id}';
-    final resolved = await _resolveTrack(song, album, sessionId);
+    final cachedPaths = await _cachedPaths([song]);
+    final resolved = await _resolveTrack(
+      song,
+      album,
+      sessionId,
+      cachedPath: cachedPaths[song.id],
+    );
     if (resolved == null) return false;
+    if (resolved.track.isLocalFile) {
+      _localSongIds.add(song.id);
+    } else {
+      _localSongIds.remove(song.id);
+    }
 
     final current = state.currentMediaIndex;
     final index = playNext
@@ -678,7 +761,72 @@ class PlaybackNotifier extends StateNotifier<PlaybackState> {
 
   Future<void> clear() async {
     await stop();
+    _localSongIds.clear();
     state = PlaybackState.initial();
+  }
+
+  Future<void> adoptCachedFiles(Map<String, String> pathsById) {
+    final pending = _adoptions.then((_) => _adoptCachedFiles(pathsById));
+    _adoptions = pending.then(
+      (_) {},
+      onError: (Object error) =>
+          debugPrint('[Playback] adopting cached files failed: $error'),
+    );
+    return pending;
+  }
+
+  Future<void> _adoptCachedFiles(Map<String, String> pathsById) async {
+    if (pathsById.isEmpty || !_target.supportsLocalFiles) return;
+    final target = _target;
+    if (target is! SwappableQueue) return;
+    final album = state.album;
+    if (album == null) return;
+
+    final songs = state.songs;
+    final queueIds = [for (final song in songs) song.id];
+    final adopted = <String>{};
+    final playing = <String>{};
+
+    for (final (index, song) in songs.indexed) {
+      if (!_queueMatches(queueIds)) return;
+      if (_localSongIds.contains(song.id)) continue;
+      final path = pathsById[song.id];
+      if (path == null) continue;
+      if (index == state.currentMediaIndex) {
+        playing.add(song.id);
+        continue;
+      }
+
+      final sessionId = _playSessionIds[song.id];
+      if (sessionId == null) continue;
+      final resolved = await _resolveTrack(
+        song,
+        album,
+        sessionId,
+        cachedPath: path,
+      );
+      if (resolved == null || !resolved.track.isLocalFile) continue;
+      if (state.songs.elementAtOrNull(index)?.id != song.id) continue;
+      if (index == state.currentMediaIndex) {
+        playing.add(song.id);
+        continue;
+      }
+
+      await _editQueue(() => target.replace(index, resolved.track));
+      adopted.add(song.id);
+      debugPrint('[Playback] adopted cached file for "${song.name}"');
+    }
+
+    _localSongIds.addAll(adopted.where((id) => !playing.contains(id)));
+  }
+
+  bool _queueMatches(List<String> queueIds) {
+    final songs = state.songs;
+    if (songs.length != queueIds.length) return false;
+    for (var i = 0; i < songs.length; i++) {
+      if (songs[i].id != queueIds[i]) return false;
+    }
+    return true;
   }
 
   void toggleRepeat() {

--- a/lib/src/domain/providers/providers.dart
+++ b/lib/src/domain/providers/providers.dart
@@ -9,6 +9,7 @@ export 'download_manager_provider.dart';
 export 'downloaded_albums_provider.dart';
 export 'downloaded_playlists_provider.dart';
 export 'favourites_provider.dart';
+export 'forward_cache_provider.dart';
 export 'genre_albums_provider.dart';
 export 'home_sections_provider.dart';
 export 'is_album_downloaded_provider.dart';

--- a/lib/src/domain/providers/queue_cache_report_provider.dart
+++ b/lib/src/domain/providers/queue_cache_report_provider.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jplayer/src/data/providers/providers.dart';
+import 'package:jplayer/src/data/storages/queue_cache_database.dart';
+import 'package:jplayer/src/domain/providers/forward_cache_provider.dart';
+
+final AutoDisposeFutureProvider<List<CacheDetail>> queueCacheReportProvider =
+    FutureProvider.autoDispose<List<CacheDetail>>((ref) {
+  ref.watch(forwardCacheProvider);
+  return ref.watch(queueCacheDatabaseProvider).detailedEntries();
+});

--- a/lib/src/presentation/pages/pages.dart
+++ b/lib/src/presentation/pages/pages.dart
@@ -13,5 +13,6 @@ export 'library_page.dart';
 export 'login_page.dart';
 export 'main_page.dart';
 export 'playlist_page.dart';
+export 'queue_cache_page.dart';
 export 'search_results_page.dart';
 export 'settings_page.dart';

--- a/lib/src/presentation/pages/queue_cache_page.dart
+++ b/lib/src/presentation/pages/queue_cache_page.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jplayer/src/core/enums/enums.dart';
+import 'package:jplayer/src/data/providers/providers.dart';
+import 'package:jplayer/src/data/storages/queue_cache_database.dart';
+import 'package:jplayer/src/domain/providers/app_settings_provider.dart';
+import 'package:jplayer/src/domain/providers/playback_provider.dart';
+import 'package:jplayer/src/domain/providers/queue_cache_report_provider.dart';
+
+class QueueCachePage extends ConsumerWidget {
+  const QueueCachePage({super.key});
+
+  static String formatBytes(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    const units = ['KB', 'MB', 'GB'];
+    var value = bytes / 1024;
+    var unit = 0;
+    while (value >= 1024 && unit < units.length - 1) {
+      value /= 1024;
+      unit++;
+    }
+    return '${value.toStringAsFixed(value >= 10 ? 0 : 1)} ${units[unit]}';
+  }
+
+  static String formatAge(DateTime moment) {
+    final elapsed = DateTime.now().difference(moment);
+    if (elapsed.inMinutes < 1) return 'just now';
+    if (elapsed.inMinutes < 60) return '${elapsed.inMinutes}m ago';
+    if (elapsed.inHours < 24) return '${elapsed.inHours}h ago';
+    return '${elapsed.inDays}d ago';
+  }
+
+  Future<void> _purge(WidgetRef ref) async {
+    await ref.read(queueCacheServiceProvider).purge();
+    ref.invalidate(queueCacheReportProvider);
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final limit = ref.watch(forwardCacheLimitProvider);
+    final report = ref.watch(queueCacheReportProvider);
+    final playback = ref.watch(playbackProvider);
+    final queueIds = {for (final song in playback.songs) song.id};
+    final playingIndex = playback.currentMediaIndex;
+    final playingId = playingIndex != null
+        ? playback.songs.elementAtOrNull(playingIndex)?.id
+        : null;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Queue cache'),
+        actions: [
+          IconButton(
+            onPressed: () => ref.invalidate(queueCacheReportProvider),
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh',
+          ),
+          IconButton(
+            onPressed: () => _purge(ref),
+            icon: const Icon(Icons.delete_outline),
+            tooltip: 'Purge cache',
+          ),
+        ],
+      ),
+      body: report.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(child: Text('$error')),
+        data: (entries) {
+          final used = entries.fold(0, (sum, e) => sum + e.sizeInBytes);
+          final missing = entries.where((e) => !e.onDisk).length;
+
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _summary(
+                theme: theme,
+                limit: limit,
+                used: used,
+                count: entries.length,
+                missing: missing,
+                queued: entries
+                    .where((e) => queueIds.contains(e.item.id))
+                    .length,
+              ),
+              const Divider(height: 1),
+              if (entries.isEmpty)
+                Expanded(
+                  child: Center(
+                    child: Text(
+                      limit.isEnabled
+                          ? 'Nothing cached yet'
+                          : 'Caching is off',
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                  ),
+                )
+              else
+                Expanded(
+                  child: ListView.separated(
+                    itemCount: entries.length,
+                    separatorBuilder: (_, _) => const Divider(height: 1),
+                    itemBuilder: (context, index) => _entryTile(
+                      theme: theme,
+                      entry: entries[index],
+                      inQueue: queueIds.contains(entries[index].item.id),
+                      isPlaying: entries[index].item.id == playingId,
+                    ),
+                  ),
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _summary({
+    required ThemeData theme,
+    required ForwardCacheLimit limit,
+    required int used,
+    required int count,
+    required int missing,
+    required int queued,
+  }) {
+    final capacity = limit.isEnabled
+        ? '${formatBytes(used)} of ${formatBytes(limit.bytes)}'
+        : '${formatBytes(used)} (limit off)';
+
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(capacity, style: theme.textTheme.titleMedium),
+          const SizedBox(height: 8),
+          if (limit.isEnabled)
+            LinearProgressIndicator(
+              value: (used / limit.bytes).clamp(0.0, 1.0),
+              minHeight: 6,
+            ),
+          const SizedBox(height: 12),
+          Text(
+            '$count cached · $queued in this queue'
+            '${missing > 0 ? ' · $missing missing on disk' : ''}',
+            style: theme.textTheme.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _entryTile({
+    required ThemeData theme,
+    required CacheDetail entry,
+    required bool inQueue,
+    required bool isPlaying,
+  }) {
+    final subtitle = [
+      formatBytes(entry.sizeInBytes),
+      'used ${formatAge(entry.lastUsedDate)}',
+      if (!entry.onDisk) 'FILE MISSING',
+    ].join(' · ');
+
+    return ListTile(
+      dense: true,
+      leading: Icon(
+        isPlaying
+            ? Icons.play_arrow
+            : entry.onDisk
+            ? Icons.offline_pin_outlined
+            : Icons.error_outline,
+        color: entry.onDisk
+            ? (isPlaying ? theme.colorScheme.primary : null)
+            : theme.colorScheme.error,
+      ),
+      title: Text(entry.item.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+      subtitle: Text(subtitle, style: theme.textTheme.bodySmall),
+      trailing: inQueue
+          ? Text('queue', style: theme.textTheme.labelSmall)
+          : null,
+    );
+  }
+}

--- a/lib/src/presentation/pages/settings_page.dart
+++ b/lib/src/presentation/pages/settings_page.dart
@@ -39,6 +39,23 @@ class SettingsPage extends ConsumerWidget {
     StartPage.browse: 'Browse',
   };
 
+  static const Map<ForwardCacheWindow, String> _forwardCacheWindowLabels = {
+    ForwardCacheWindow.min10: '10 min',
+    ForwardCacheWindow.min15: '15 min',
+    ForwardCacheWindow.min30: '30 min',
+    ForwardCacheWindow.min45: '45 min',
+    ForwardCacheWindow.min60: '60 min',
+  };
+
+  static const Map<ForwardCacheLimit, String> _forwardCacheLabels = {
+    ForwardCacheLimit.off: 'Off',
+    ForwardCacheLimit.mb500: '500 MB',
+    ForwardCacheLimit.gb1: '1 GB',
+    ForwardCacheLimit.gb2: '2 GB',
+    ForwardCacheLimit.gb4: '4 GB',
+    ForwardCacheLimit.gb8: '8 GB',
+  };
+
   ButtonStyle get _buttonStyle => TextButton.styleFrom(
     padding: _buttonPadding,
     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
@@ -109,78 +126,113 @@ class SettingsPage extends ConsumerWidget {
                 ),
               ),
             ),
-            Padding(
-              padding: EdgeInsets.only(
-                left: contentPadding.left,
-                right: contentPadding.right,
-              ),
-              child: Wrap(
-                direction: Axis.vertical,
-                spacing: 4,
-                children: [
-                  _librariesButton(context),
-                  if (kDebugMode) _settingsButton(context),
-                  _changelogButton(context, device),
-                  _sectionHeader('Home Page'),
-                  _settingCheckbox(
-                    ref: ref,
-                    setting: AppSetting.generatedPlaylistsDisabled,
-                    label: 'Disable auto-generated playlists',
-                  ),
-                  _settingCheckbox(
-                    ref: ref,
-                    setting: AppSetting.favouritesHidden,
-                    label: 'Hide favourites',
-                  ),
-                  _settingCheckbox(
-                    ref: ref,
-                    setting: AppSetting.recentlyPlayedHidden,
-                    label: 'Hide recently played',
-                  ),
-                  _sectionHeader('UI'),
-                  _settingDropdown<StartPage>(
-                    context: context,
-                    label: 'Default start page',
-                    value: ref.watch(defaultStartPageProvider),
-                    options: _startPageLabels,
-                    onChanged: (value) => ref
-                        .read(appSettingsProvider.notifier)
-                        .setValue(AppSetting.defaultStartPage, value.name),
-                  ),
-                  _settingDropdown<ItemList>(
-                    context: context,
-                    label: 'Default browse tab',
-                    value: ref.watch(defaultBrowseTabProvider),
-                    options: _browseTabLabels,
-                    onChanged: (value) => ref
-                        .read(appSettingsProvider.notifier)
-                        .setValue(AppSetting.defaultBrowseTab, value.name),
-                  ),
-                  if (!device.isMobile) ...[
-                    _sectionHeader('Studio Mode'),
-                    if (supportsWindowFullscreen)
-                      _settingCheckbox(
-                        ref: ref,
-                        setting: AppSetting.studioModeFullscreen,
-                        label:
-                            'Make player full screen when Studio Mode enabled',
-                      ),
+            Expanded(
+              child: SingleChildScrollView(
+                padding: EdgeInsets.only(
+                  left: contentPadding.left,
+                  right: contentPadding.right,
+                  bottom: contentPadding.bottom,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  spacing: 4,
+                  children: [
+                    _librariesButton(context),
+                    if (kDebugMode) _settingsButton(context),
+                    if (kDebugMode) _queueCacheButton(context),
+                    _changelogButton(context, device),
+                    _sectionHeader('Home Page'),
                     _settingCheckbox(
                       ref: ref,
-                      setting: AppSetting.studioModeAnimation,
-                      label: 'Enable Studio Mode animation',
+                      setting: AppSetting.generatedPlaylistsDisabled,
+                      label: 'Disable auto-generated playlists',
                     ),
+                    _settingCheckbox(
+                      ref: ref,
+                      setting: AppSetting.favouritesHidden,
+                      label: 'Hide favourites',
+                    ),
+                    _settingCheckbox(
+                      ref: ref,
+                      setting: AppSetting.recentlyPlayedHidden,
+                      label: 'Hide recently played',
+                    ),
+                    _sectionHeader('UI'),
+                    _settingDropdown<StartPage>(
+                      context: context,
+                      label: 'Default start page',
+                      value: ref.watch(defaultStartPageProvider),
+                      options: _startPageLabels,
+                      onChanged: (value) => ref
+                          .read(appSettingsProvider.notifier)
+                          .setValue(AppSetting.defaultStartPage, value.name),
+                    ),
+                    _settingDropdown<ItemList>(
+                      context: context,
+                      label: 'Default browse tab',
+                      value: ref.watch(defaultBrowseTabProvider),
+                      options: _browseTabLabels,
+                      onChanged: (value) => ref
+                          .read(appSettingsProvider.notifier)
+                          .setValue(AppSetting.defaultBrowseTab, value.name),
+                    ),
+                    if (device.isMobile) ...[
+                      _sectionHeader('Offline'),
+                      _settingDropdown<ForwardCacheLimit>(
+                        context: context,
+                        label: 'Cache queue for offline',
+                        value: ref.watch(forwardCacheLimitProvider),
+                        options: _forwardCacheLabels,
+                        onChanged: (value) => ref
+                            .read(appSettingsProvider.notifier)
+                            .setValue(AppSetting.forwardCacheLimit, value.name),
+                      ),
+                      if (ref.watch(forwardCacheLimitProvider).isEnabled)
+                        _settingDropdown<ForwardCacheWindow>(
+                          context: context,
+                          label: 'Cache ahead',
+                          value: ref.watch(forwardCacheWindowProvider),
+                          options: _forwardCacheWindowLabels,
+                          onChanged: (value) => ref
+                              .read(appSettingsProvider.notifier)
+                              .setValue(
+                                AppSetting.forwardCacheWindow,
+                                value.name,
+                              ),
+                        ),
+                    ],
+                    if (!device.isMobile) ...[
+                      _sectionHeader('Studio Mode'),
+                      if (supportsWindowFullscreen)
+                        _settingCheckbox(
+                          ref: ref,
+                          setting: AppSetting.studioModeFullscreen,
+                          label:
+                              'Make player full screen when Studio Mode enabled',
+                        ),
+                      _settingCheckbox(
+                        ref: ref,
+                        setting: AppSetting.studioModeAnimation,
+                        label: 'Enable Studio Mode animation',
+                      ),
+                    ],
+                    if (!device.isDesktop) _logOutButton(ref),
                   ],
-                  if (!device.isDesktop) _logOutButton(ref),
-                ],
+                ),
               ),
             ),
-            SizedBox(height: contentPadding.bottom),
           ],
         ),
       ),
     );
   }
+
+  Widget _queueCacheButton(BuildContext context) => TextButton.icon(
+    onPressed: () => context.pushNamed(Routes.queueCache.name),
+    style: _buttonStyle,
+    icon: const Icon(JPlayer.download),
+    label: const Text('Queue cache'),
+  );
 
   Widget _settingsButton(BuildContext context) => TextButton.icon(
     onPressed: () => _onPaletteSettingsPressed(context),

--- a/lib/src/presentation/widgets/item_row_view.dart
+++ b/lib/src/presentation/widgets/item_row_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jplayer/resources/resources.dart';
 import 'package:jplayer/src/domain/models/models.dart';
 import 'package:jplayer/src/presentation/widgets/widgets.dart';
 import 'package:jplayer/src/providers/image_service_provider.dart';
@@ -71,6 +72,12 @@ class _ItemRowViewState extends ConsumerState<ItemRowView> {
           width: imageSize,
           height: imageSize,
           fit: BoxFit.cover,
+          errorBuilder: (context, error, stackTrace) => Image.asset(
+            Images.album,
+            width: imageSize,
+            height: imageSize,
+            fit: BoxFit.cover,
+          ),
         ),
       ),
       leadingToTitle: isMobile ? 12 : 16,

--- a/lib/src/presentation/widgets/library_view.dart
+++ b/lib/src/presentation/widgets/library_view.dart
@@ -31,6 +31,8 @@ class LibraryView extends ConsumerWidget {
             child: Image(
               image: libraryImage(ref),
               fit: BoxFit.fitWidth,
+              errorBuilder: (context, error, stackTrace) =>
+                  Image.asset(Images.librarySample, fit: BoxFit.fitWidth),
             ),
           ),
           Text(

--- a/lib/src/presentation/widgets/song_row_view.dart
+++ b/lib/src/presentation/widgets/song_row_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jplayer/resources/resources.dart';
 import 'package:jplayer/src/core/enums/download_status.dart';
 import 'package:jplayer/src/domain/models/models.dart';
 import 'package:jplayer/src/domain/providers/providers.dart';
@@ -110,6 +111,12 @@ class SongRowView extends ConsumerWidget {
                 width: imageSize,
                 height: imageSize,
                 fit: BoxFit.cover,
+                errorBuilder: (context, error, stackTrace) => Image.asset(
+                  Images.album,
+                  width: imageSize,
+                  height: imageSize,
+                  fit: BoxFit.cover,
+                ),
               ),
             ),
       leadingToTitle: isMobile ? 12 : 16,

--- a/lib/src/providers/auth_provider.dart
+++ b/lib/src/providers/auth_provider.dart
@@ -20,6 +20,7 @@ import 'package:jplayer/src/data/params/params.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
 import 'package:jplayer/src/data/services/server_probe_service.dart';
 import 'package:jplayer/src/domain/providers/current_user_provider.dart';
+import 'package:jplayer/src/domain/providers/forward_cache_provider.dart';
 import 'package:jplayer/src/domain/providers/playback_provider.dart';
 import 'package:jplayer/src/providers/base_url_provider.dart';
 import 'package:jplayer/src/providers/current_server_id_provider.dart';
@@ -220,6 +221,7 @@ class AuthNotifier extends AsyncNotifier<bool?> {
     state = const AsyncLoading();
     try {
       await _stopPlayback();
+      await _purgeQueueCache();
       PaintingBinding.instance.imageCache.clear();
       await Future.wait([
         ref.read(sharedPreferencesProvider).requireValue.clear(),
@@ -237,6 +239,15 @@ class AuthNotifier extends AsyncNotifier<bool?> {
   Future<void> _stopPlayback() async {
     try {
       await ref.read(playbackProvider.notifier).clear();
+    } on Object {
+      return;
+    }
+  }
+
+  Future<void> _purgeQueueCache() async {
+    try {
+      await ref.read(forwardCacheProvider.notifier).cancelPending();
+      await ref.read(queueCacheServiceProvider).purge();
     } on Object {
       return;
     }

--- a/lib/src/providers/session_providers.dart
+++ b/lib/src/providers/session_providers.dart
@@ -9,6 +9,7 @@ final sessionScopedProviders = <ProviderOrFamily>[
   currentLibraryProvider,
   setPlaybackProvider,
   downloadManagerProvider,
+  forwardCacheProvider,
   downloadedAlbumsProvider,
   downloadedPlaylistsProvider,
   currentDayProvider,

--- a/lib/src/screen_factory.dart
+++ b/lib/src/screen_factory.dart
@@ -145,6 +145,15 @@ class ScreenFactory {
     );
   }
 
+  Page<void> queueCachePage(
+    BuildContext context,
+    GoRouterState router,
+  ) {
+    return const NoTransitionPage(
+      child: QueueCachePage(),
+    );
+  }
+
   Page<void> palettePage(
     BuildContext context,
     GoRouterState router,

--- a/test/core/audio/queue_shuffle_order_test.dart
+++ b/test/core/audio/queue_shuffle_order_test.dart
@@ -60,6 +60,24 @@ void main() {
       expect(order.indices.toSet(), {0, 1, 2, 3, 4});
     });
 
+    test('reports the shuffle position of a queue index', () {
+      final order = orderOf([2, 0, 3, 1]);
+
+      expect(order.positionOfIndex(3), 2);
+      expect(order.positionOfIndex(9), isNull);
+    });
+
+    test('keeps a swapped entry in its own shuffle slot', () {
+      final order = orderOf([2, 0, 3, 1]);
+
+      final position = order.positionOfIndex(1);
+      order.removeRange(1, 2);
+      order.nextInsertPosition = position;
+      order.insert(1, 1);
+
+      expect(order.indices, [2, 0, 3, 1]);
+    });
+
     test('drops a removed range and closes the gap', () {
       final order = orderOf([2, 0, 3, 1]);
 

--- a/test/core/downloads/cache_downloader_test.dart
+++ b/test/core/downloads/cache_downloader_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/core/downloads/cache_downloader.dart';
+
+void main() {
+  group('BackgroundCacheDownloader', () {
+    test('- namespaces task ids away from user downloads', () {
+      expect(
+        BackgroundCacheDownloader.taskIdFor('song-1'),
+        'queue-cache-song-1',
+      );
+      expect(BackgroundCacheDownloader.taskIdFor('song-1'), isNot('song-1'));
+    });
+  });
+}

--- a/test/core/errors/image_error_filter_test.dart
+++ b/test/core/errors/image_error_filter_test.dart
@@ -1,0 +1,53 @@
+import 'dart:io' show SocketException;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/core/errors/image_error_filter.dart';
+
+void main() {
+  FlutterErrorDetails imageFailure(Object exception) => FlutterErrorDetails(
+    exception: exception,
+    library: 'image resource service',
+  );
+
+  group('isUnreachableImageFailure', () {
+    test('- catches a failed host lookup', () {
+      expect(
+        isUnreachableImageFailure(
+          imageFailure(const SocketException("Failed host lookup: 'jelly'")),
+        ),
+        isTrue,
+      );
+    });
+
+    test('- catches a client exception wrapping a socket failure', () {
+      expect(
+        isUnreachableImageFailure(
+          imageFailure(
+            Exception('ClientException with SocketException: host lookup'),
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('- leaves a decode failure alone', () {
+      expect(
+        isUnreachableImageFailure(imageFailure(Exception('Invalid image'))),
+        isFalse,
+      );
+    });
+
+    test('- leaves errors from other libraries alone', () {
+      expect(
+        isUnreachableImageFailure(
+          const FlutterErrorDetails(
+            exception: SocketException('Failed host lookup'),
+            library: 'widgets library',
+          ),
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/data/services/album_cover_store_test.dart
+++ b/test/data/services/album_cover_store_test.dart
@@ -1,0 +1,87 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/core/downloads/download_paths.dart';
+import 'package:jplayer/src/data/services/album_cover_store.dart';
+import 'package:path/path.dart' hide equals;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory root;
+  late AlbumCoverStore store;
+  final requested = <Uri>[];
+  List<int>? response = [1, 2, 3];
+
+  final artwork = Uri.parse('http://server/Items/album-1/Images/Primary');
+
+  File coverOf(String albumId) =>
+      File(join(root.path, albumId, DownloadPaths.coverFileName));
+
+  setUp(() async {
+    root = await Directory.systemTemp.createTemp('covers');
+    DownloadPaths.root = root.path;
+    requested.clear();
+    response = [1, 2, 3];
+    store = AlbumCoverStore(
+      fetch: (uri) async {
+        requested.add(uri);
+        return response;
+      },
+    );
+  });
+
+  tearDown(() async {
+    DownloadPaths.root = null;
+    if (root.existsSync()) await root.delete(recursive: true);
+  });
+
+  group('AlbumCoverStore', () {
+    test('- stores a cover for an album', () async {
+      final file = await store.ensure('album-1', artwork);
+
+      expect(file, isNotNull);
+      expect(coverOf('album-1').existsSync(), isTrue);
+      expect(coverOf('album-1').lengthSync(), 3);
+      expect(requested, [artwork]);
+    });
+
+    test('- fetches a cover only once', () async {
+      await store.ensure('album-1', artwork);
+      await store.ensure('album-1', artwork);
+
+      expect(requested, hasLength(1));
+    });
+
+    test('- does nothing without an image url', () async {
+      expect(await store.ensure('album-1', null), isNull);
+      expect(requested, isEmpty);
+    });
+
+    test('- leaves nothing behind when the fetch comes back empty', () async {
+      response = null;
+
+      expect(await store.ensure('album-1', artwork), isNull);
+      expect(coverOf('album-1').existsSync(), isFalse);
+    });
+
+    test('- sweeps covers nothing references', () async {
+      await store.ensure('album-1', artwork);
+      await store.ensure('album-2', artwork);
+
+      await store.sweepUnreferenced({'album-1'});
+
+      expect(coverOf('album-1').existsSync(), isTrue);
+      expect(coverOf('album-2').existsSync(), isFalse);
+    });
+
+    test('- never sweeps a downloaded album', () async {
+      await store.ensure('album-3', artwork);
+      File(join(root.path, 'album-3', 'song.flac')).writeAsBytesSync([1]);
+
+      await store.sweepUnreferenced(const {});
+
+      expect(coverOf('album-3').existsSync(), isTrue);
+    });
+  });
+}

--- a/test/data/services/queue_cache_service_test.dart
+++ b/test/data/services/queue_cache_service_test.dart
@@ -83,6 +83,7 @@ void main() {
     database = QueueCacheDatabase(DownloadDatabase(serverId: 'server-1'));
     service = QueueCacheService(
       database: database,
+      downloads: DownloadDatabase(serverId: 'server-1'),
       downloader: downloader,
       deviceId: 'test-device',
       covers: AlbumCoverStore(
@@ -268,6 +269,34 @@ void main() {
       expect(await database.cachedIds(), {'a'});
       expect(await other.cachedIds(), isEmpty);
       expect(theirFile.existsSync(), isFalse);
+    });
+
+    test('- reconciling keeps a downloaded album cover', () async {
+      final downloads = DownloadDatabase(serverId: 'server-1');
+      const album = LibraryItem(
+        id: 'album-kept',
+        name: 'Album',
+        kind: ItemKind.album,
+      );
+      await downloads.insertDownloadedAlbum(
+        album,
+        files: [File(join(filesDir.path, 'placeholder'))..writeAsBytesSync([1])],
+      );
+      final kept = File(
+        join(coversDir.path, 'album-kept', DownloadPaths.coverFileName),
+      );
+      await kept.parent.create(recursive: true);
+      kept.writeAsBytesSync([1, 2, 3]);
+      final orphan = File(
+        join(coversDir.path, 'album-gone', DownloadPaths.coverFileName),
+      );
+      await orphan.parent.create(recursive: true);
+      orphan.writeAsBytesSync([1, 2, 3]);
+
+      await service.reconcile();
+
+      expect(kept.existsSync(), isTrue);
+      expect(orphan.existsSync(), isFalse);
     });
 
     test('- prunes rows the OS reclaimed', () async {

--- a/test/data/services/queue_cache_service_test.dart
+++ b/test/data/services/queue_cache_service_test.dart
@@ -1,0 +1,292 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/core/audio/stream_target_profile.dart';
+import 'package:jplayer/src/core/downloads/cache_downloader.dart';
+import 'package:jplayer/src/core/downloads/download_paths.dart';
+import 'package:jplayer/src/data/backend/media_server_client.dart';
+import 'package:jplayer/src/data/backend/stream_source.dart';
+import 'package:jplayer/src/data/services/album_cover_store.dart';
+import 'package:jplayer/src/data/services/queue_cache_service.dart';
+import 'package:jplayer/src/data/storages/download_database.dart';
+import 'package:jplayer/src/data/storages/queue_cache_database.dart';
+import 'package:jplayer/src/domain/models/models.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:path/path.dart' hide equals;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class _FakeDownloader implements CacheDownloader {
+  _FakeDownloader(this._directory);
+
+  final Directory _directory;
+  final requested = <String>[];
+  final cancelled = <String>[];
+  final failIds = <String>{};
+  int bytes = 1024;
+
+  @override
+  Future<String> directoryPath() async => _directory.path;
+
+  @override
+  Future<String?> fetch({
+    required String id,
+    required String url,
+    required String fileName,
+  }) async {
+    requested.add(id);
+    if (failIds.contains(id)) return null;
+    final file = File(join(_directory.path, fileName))
+      ..writeAsBytesSync(List.filled(bytes, 0));
+    return file.path;
+  }
+
+  @override
+  Future<void> cancel(String id) async => cancelled.add(id);
+}
+
+class _MockMediaServerClient extends Mock implements MediaServerClient {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+
+  late Directory filesDir;
+  late Directory coversDir;
+  late List<Uri> coverRequests;
+  late _FakeDownloader downloader;
+  late QueueCacheDatabase database;
+  late QueueCacheService service;
+  late MediaServerClient client;
+
+  LibraryItem song(String id) =>
+      LibraryItem(id: id, name: 'song $id', kind: ItemKind.song);
+
+  setUpAll(() async {
+    final dbDir = await Directory.systemTemp.createTemp('queue_cache_svc_db');
+    await databaseFactory.setDatabasesPath(dbDir.path);
+    registerFallbackValue(song('fallback'));
+    registerFallbackValue(StreamTargetProfile.download(isAndroid: false));
+    registerFallbackValue(ImageKind.primary);
+  });
+
+  setUp(() async {
+    filesDir = await Directory.systemTemp.createTemp('queue_cache_svc');
+    final dir = await getDatabasesPath();
+    await databaseFactory.deleteDatabase(join(dir, 'downloads.db'));
+
+    coversDir = await Directory.systemTemp.createTemp('queue_cache_covers');
+    DownloadPaths.root = coversDir.path;
+    coverRequests = [];
+
+    downloader = _FakeDownloader(filesDir);
+    database = QueueCacheDatabase(DownloadDatabase(serverId: 'server-1'));
+    service = QueueCacheService(
+      database: database,
+      downloader: downloader,
+      deviceId: 'test-device',
+      covers: AlbumCoverStore(
+        fetch: (uri) async {
+          coverRequests.add(uri);
+          return [1, 2, 3];
+        },
+      ),
+    );
+    client = _MockMediaServerClient();
+    when(
+      () => client.resolveStreamSource(
+        any(),
+        playSessionId: any(named: 'playSessionId'),
+        target: any(named: 'target'),
+      ),
+    ).thenAnswer(
+      (_) async => StreamSource(
+        uri: Uri.parse('http://server/audio/stream'),
+        isHls: false,
+        outputContainer: 'flac',
+        mimeType: 'audio/flac',
+      ),
+    );
+  });
+
+  tearDown(() async {
+    DownloadPaths.root = null;
+    if (filesDir.existsSync()) await filesDir.delete(recursive: true);
+    if (coversDir.existsSync()) await coversDir.delete(recursive: true);
+  });
+
+  Future<void> settle() =>
+      Future<void>.delayed(const Duration(milliseconds: 5));
+
+  group('QueueCacheService', () {
+    test('- caches a song through the download profile', () async {
+      final path = await service.cache(song('a'), client);
+
+      expect(path, isNotNull);
+      expect(File(path!).existsSync(), isTrue);
+      expect(await database.pathOf('a'), path);
+      expect(downloader.requested, ['a']);
+
+      final captured = verify(
+        () => client.resolveStreamSource(
+          any(),
+          playSessionId: captureAny(named: 'playSessionId'),
+          target: captureAny(named: 'target'),
+        ),
+      ).captured;
+      expect(captured.first, 'cache-test-device-a');
+      expect((captured.last as StreamTargetProfile).supportsHls, isFalse);
+    });
+
+    test('- stores the album cover alongside the audio', () async {
+      final artwork = Uri.parse('http://server/Items/album-1/Images/Primary');
+      when(
+        () => client.imageUri(
+          any(),
+          kind: any(named: 'kind'),
+          size: any(named: 'size'),
+        ),
+      ).thenReturn(artwork);
+      const track = LibraryItem(
+        id: 'a',
+        name: 'song a',
+        kind: ItemKind.song,
+        albumId: 'album-1',
+      );
+
+      await service.cache(track, client);
+
+      expect(coverRequests, [artwork]);
+      expect(
+        File(
+          join(coversDir.path, 'album-1', DownloadPaths.coverFileName),
+        ).existsSync(),
+        isTrue,
+      );
+    });
+
+    test('- skips the cover when the song has no album', () async {
+      await service.cache(song('a'), client);
+
+      expect(coverRequests, isEmpty);
+    });
+
+    test('- leaves nothing behind when a fetch fails', () async {
+      downloader.failIds.add('a');
+
+      expect(await service.cache(song('a'), client), isNull);
+      expect(await database.cachedIds(), isEmpty);
+    });
+
+    test('- leaves nothing behind when the server errors', () async {
+      when(
+        () => client.resolveStreamSource(
+          any(),
+          playSessionId: any(named: 'playSessionId'),
+          target: any(named: 'target'),
+        ),
+      ).thenThrow(Exception('offline'));
+
+      expect(await service.cache(song('a'), client), isNull);
+      expect(await database.cachedIds(), isEmpty);
+      expect(downloader.requested, isEmpty);
+    });
+
+    test('- evicts least recently used entries outside the queue', () async {
+      downloader.bytes = 1000;
+      await service.cache(song('a'), client);
+      await settle();
+      await service.cache(song('b'), client);
+      await settle();
+      await service.cache(song('c'), client);
+
+      await service.enforceLimit(2000, keepIds: {'c'});
+
+      expect(await database.cachedIds(), {'b', 'c'});
+    });
+
+    test('- keeps queued entries even when over the limit', () async {
+      downloader.bytes = 1000;
+      await service.cache(song('a'), client);
+      await settle();
+      await service.cache(song('b'), client);
+
+      await service.enforceLimit(500, keepIds: {'a', 'b'});
+
+      expect(await database.cachedIds(), {'a', 'b'});
+    });
+
+    test('- keeps the playing queue when the limit is switched off', () async {
+      await service.cache(song('a'), client);
+      await settle();
+      await service.cache(song('b'), client);
+
+      await service.enforceLimit(0, keepIds: {'a'});
+
+      expect(await database.cachedIds(), {'a'});
+    });
+
+    test('- sheds everything once the queue moves on', () async {
+      await service.cache(song('a'), client);
+
+      await service.enforceLimit(0);
+
+      expect(await database.cachedIds(), isEmpty);
+      expect(await database.totalBytes(), 0);
+    });
+
+    test('- purging clears rows and stray files alike', () async {
+      await service.cache(song('a'), client);
+      final stray = File(join(filesDir.path, 'stray.flac'))
+        ..writeAsBytesSync([1, 2, 3]);
+
+      await service.purge();
+
+      expect(await database.cachedIds(), isEmpty);
+      expect(stray.existsSync(), isFalse);
+      expect(filesDir.listSync(), isEmpty);
+    });
+
+    test('- reconciles rows whose file vanished', () async {
+      final path = await service.cache(song('a'), client);
+      await File(path!).delete();
+
+      await service.reconcile();
+
+      expect(await database.cachedIds(), isEmpty);
+    });
+
+    test("- reconciling drops another server's entries", () async {
+      final other = QueueCacheDatabase(DownloadDatabase(serverId: 'server-2'));
+      await service.cache(song('a'), client);
+      final theirFile = File(join(filesDir.path, 'theirs.flac'))
+        ..writeAsBytesSync([1, 2, 3]);
+      await other.insert(song('b'), file: theirFile);
+
+      await service.reconcile();
+
+      expect(await database.cachedIds(), {'a'});
+      expect(await other.cachedIds(), isEmpty);
+      expect(theirFile.existsSync(), isFalse);
+    });
+
+    test('- prunes rows the OS reclaimed', () async {
+      final path = await service.cache(song('a'), client);
+      await File(path!).delete();
+
+      expect(await service.pruneMissing(), 1);
+      expect(await database.totalBytes(), 0);
+    });
+
+    test('- reconciles files nothing knows about', () async {
+      await service.cache(song('a'), client);
+      final orphan = File(join(filesDir.path, 'orphan.flac'))
+        ..writeAsBytesSync([1, 2, 3]);
+
+      await service.reconcile();
+
+      expect(await database.cachedIds(), {'a'});
+      expect(orphan.existsSync(), isFalse);
+    });
+  });
+}

--- a/test/data/storages/download_database_test.dart
+++ b/test/data/storages/download_database_test.dart
@@ -136,6 +136,18 @@ void main() {
       expect(await emby.isAlbumDownloaded(album.id), isFalse);
     });
 
+    test('- reports downloaded ids for the current server only', () async {
+      final jellyfin = DownloadDatabase(serverId: 'server-a');
+      final emby = DownloadDatabase(serverId: 'server-b');
+      final song = buildSong();
+
+      await jellyfin.insertDownloadedSong(song, file: songFile);
+
+      expect(await jellyfin.downloadedIds([song.id, 'missing']), {song.id});
+      expect(await emby.downloadedIds([song.id]), isEmpty);
+      expect(await jellyfin.downloadedIds(const []), isEmpty);
+    });
+
     test('- does not delete another server\'s rows', () async {
       final jellyfin = DownloadDatabase(serverId: 'server-a');
       final emby = DownloadDatabase(serverId: 'server-b');

--- a/test/data/storages/download_database_test.dart
+++ b/test/data/storages/download_database_test.dart
@@ -148,6 +148,20 @@ void main() {
       expect(await jellyfin.downloadedIds(const []), isEmpty);
     });
 
+    test('- reports album ids from albums and songs alike', () async {
+      final jellyfin = DownloadDatabase(serverId: 'server-a');
+      final emby = DownloadDatabase(serverId: 'server-b');
+      final album = buildAlbum();
+      final song = buildSong();
+
+      await jellyfin.insertDownloadedAlbum(album, files: [songFile]);
+      await emby.insertDownloadedSong(song, file: songFile);
+
+      final ids = await jellyfin.downloadedAlbumIds();
+
+      expect(ids, containsAll([album.id, song.albumId]));
+    });
+
     test('- does not delete another server\'s rows', () async {
       final jellyfin = DownloadDatabase(serverId: 'server-a');
       final emby = DownloadDatabase(serverId: 'server-b');

--- a/test/data/storages/queue_cache_database_test.dart
+++ b/test/data/storages/queue_cache_database_test.dart
@@ -1,0 +1,229 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/data/storages/download_database.dart';
+import 'package:jplayer/src/data/storages/queue_cache_database.dart';
+import 'package:jplayer/src/domain/models/models.dart';
+import 'package:path/path.dart' hide equals;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+
+  late Directory filesDir;
+
+  setUpAll(() async {
+    final dbDir = await Directory.systemTemp.createTemp('queue_cache_db');
+    await databaseFactory.setDatabasesPath(dbDir.path);
+  });
+
+  setUp(() async {
+    filesDir = await Directory.systemTemp.createTemp('queue_cache_files');
+  });
+
+  tearDown(() async {
+    if (filesDir.existsSync()) await filesDir.delete(recursive: true);
+  });
+
+  LibraryItem song(String id) =>
+      LibraryItem(id: id, name: 'song $id', kind: ItemKind.song);
+
+  File cachedFile(String id, {int bytes = 1024}) {
+    final file = File(join(filesDir.path, '$id.flac'))
+      ..writeAsBytesSync(List.filled(bytes, 0));
+    return file;
+  }
+
+  Future<void> deleteDb() async {
+    final dir = await getDatabasesPath();
+    await databaseFactory.deleteDatabase(join(dir, 'downloads.db'));
+  }
+
+  Future<QueueCacheDatabase> freshDb({String serverId = 'server-1'}) async {
+    await deleteDb();
+    return QueueCacheDatabase(DownloadDatabase(serverId: serverId));
+  }
+
+  Future<void> settle() =>
+      Future<void>.delayed(const Duration(milliseconds: 5));
+
+  group('QueueCacheDatabase', () {
+    test('- stores a cached entry and reads it back', () async {
+      final database = await freshDb();
+      final file = cachedFile('a', bytes: 2048);
+
+      await database.insert(song('a'), file: file);
+
+      expect(await database.pathOf('a'), file.path);
+      expect(await database.cachedIds(), {'a'});
+      expect(await database.totalBytes(), 2048);
+    });
+
+    test('- skips entries whose file vanished', () async {
+      final database = await freshDb();
+      final kept = cachedFile('a');
+      final lost = cachedFile('b');
+      await database.insert(song('a'), file: kept);
+      await database.insert(song('b'), file: lost);
+
+      await lost.delete();
+
+      expect(await database.pathsFor(['a', 'b']), {'a': kept.path});
+    });
+
+    test('- returns nothing when no ids are asked for', () async {
+      final database = await freshDb();
+      await database.insert(song('a'), file: cachedFile('a'));
+
+      expect(await database.pathsFor(const []), isEmpty);
+    });
+
+    test('- touching an entry moves it off the eviction front', () async {
+      final database = await freshDb();
+      await database.insert(song('a'), file: cachedFile('a'));
+      await settle();
+      await database.insert(song('b'), file: cachedFile('b'));
+      await settle();
+
+      await database.touch('a');
+
+      final candidates = await database.leastRecentlyUsed();
+      expect([for (final entry in candidates) entry.id], ['b', 'a']);
+    });
+
+    test('- never offers the current queue for eviction', () async {
+      final database = await freshDb();
+      await database.insert(song('a'), file: cachedFile('a'));
+      await settle();
+      await database.insert(song('b'), file: cachedFile('b'));
+
+      final candidates = await database.leastRecentlyUsed(
+        excludedIds: {'a'},
+      );
+
+      expect([for (final entry in candidates) entry.id], ['b']);
+    });
+
+    test('- deleting an entry removes its row and its file', () async {
+      final database = await freshDb();
+      final file = cachedFile('a');
+      await database.insert(song('a'), file: file);
+
+      await database.delete('a');
+
+      expect(await database.cachedIds(), isEmpty);
+      expect(await database.totalBytes(), 0);
+      expect(file.existsSync(), isFalse);
+    });
+
+    test('- clearing only touches the current server', () async {
+      final first = await freshDb();
+      final second = QueueCacheDatabase(
+        DownloadDatabase(serverId: 'server-2'),
+      );
+      final mine = cachedFile('a');
+      final theirs = cachedFile('b');
+      await first.insert(song('a'), file: mine);
+      await second.insert(song('b'), file: theirs);
+
+      await first.deleteAll();
+
+      expect(await first.cachedIds(), isEmpty);
+      expect(await second.cachedIds(), {'b'});
+      expect(mine.existsSync(), isFalse);
+      expect(theirs.existsSync(), isTrue);
+    });
+
+    test('- reads back a long queue in chunks', () async {
+      final database = await freshDb();
+      final ids = [for (var i = 0; i < 1200; i++) 'song-$i'];
+      for (final id in ids.take(3)) {
+        await database.insert(song(id), file: cachedFile(id));
+      }
+
+      final paths = await database.pathsFor(ids);
+
+      expect(paths.keys, ids.take(3));
+    });
+
+    test('- prunes rows whose file vanished', () async {
+      final database = await freshDb();
+      final kept = cachedFile('a');
+      final lost = cachedFile('b', bytes: 2048);
+      await database.insert(song('a'), file: kept);
+      await database.insert(song('b'), file: lost);
+      await lost.delete();
+
+      expect(await database.pruneMissing(), 1);
+      expect(await database.cachedIds(), {'a'});
+      expect(await database.totalBytes(), 1024);
+    });
+
+    test('- drops entries belonging to other servers', () async {
+      final mine = await freshDb();
+      final theirs = QueueCacheDatabase(
+        DownloadDatabase(serverId: 'server-2'),
+      );
+      final myFile = cachedFile('a');
+      final theirFile = cachedFile('b');
+      await mine.insert(song('a'), file: myFile);
+      await theirs.insert(song('b'), file: theirFile);
+
+      await mine.deleteForeignServers();
+
+      expect(await mine.cachedIds(), {'a'});
+      expect(await theirs.cachedIds(), isEmpty);
+      expect(myFile.existsSync(), isTrue);
+      expect(theirFile.existsSync(), isFalse);
+    });
+
+    test('- keeps every server when it has no server id', () async {
+      final legacy = await freshDb(serverId: '');
+      final scoped = QueueCacheDatabase(
+        DownloadDatabase(serverId: 'server-2'),
+      );
+      await scoped.insert(song('b'), file: cachedFile('b'));
+
+      await legacy.deleteForeignServers();
+
+      expect(await scoped.cachedIds(), {'b'});
+    });
+
+    test('- sees file paths across every server', () async {
+      final first = await freshDb();
+      final second = QueueCacheDatabase(
+        DownloadDatabase(serverId: 'server-2'),
+      );
+      final mine = cachedFile('a');
+      final theirs = cachedFile('b');
+      await first.insert(song('a'), file: mine);
+      await second.insert(song('b'), file: theirs);
+
+      expect(await first.allFilePaths(), {mine.path, theirs.path});
+    });
+  });
+
+  group('downloads.db v5 -> v6 migration', () {
+    test('- adds the QueueCache table', () async {
+      await deleteDb();
+      final dir = await getDatabasesPath();
+      final legacy = await databaseFactory.openDatabase(
+        join(dir, 'downloads.db'),
+        options: OpenDatabaseOptions(
+          version: 5,
+          onCreate: (db, version) async {},
+        ),
+      );
+      await legacy.close();
+
+      final database = QueueCacheDatabase(
+        DownloadDatabase(serverId: 'server-1'),
+      );
+      await database.insert(song('a'), file: cachedFile('a'));
+
+      expect(await database.cachedIds(), {'a'});
+    });
+  });
+}

--- a/test/domain/playback/local_playback_target_test.dart
+++ b/test/domain/playback/local_playback_target_test.dart
@@ -21,6 +21,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(<AudioSource>[]);
+    registerFallbackValue(AudioSource.uri(Uri.parse('http://jelly.local')));
     registerFallbackValue(Duration.zero);
     registerFallbackValue(QueueShuffleOrder());
   });
@@ -240,6 +241,53 @@ void main() {
 
       expect(attempts, 2);
       verify(player.stop).called(1);
+    });
+  });
+
+  group('replacing a queued source', () {
+    setUp(() {
+      when(() => player.removeAudioSourceAt(any())).thenAnswer((_) async {});
+      when(
+        () => player.insertAudioSource(any(), any()),
+      ).thenAnswer((_) async {});
+    });
+
+    test('- swaps the source sitting at that index', () async {
+      when(() => player.shuffleModeEnabled).thenReturn(false);
+
+      await target.replace(1, trackWith());
+
+      verifyInOrder([
+        () => player.removeAudioSourceAt(1),
+        () => player.insertAudioSource(1, any()),
+      ]);
+    });
+
+    test('- holds the entry in its shuffle slot', () async {
+      when(() => player.shuffleModeEnabled).thenReturn(true);
+
+      await target.load(
+        [trackWith(), trackWith(), trackWith()],
+        initialIndex: 0,
+        initialPosition: Duration.zero,
+        autoPlay: false,
+      );
+      final order =
+          verify(
+                () => player.setAudioSources(
+                  any(),
+                  initialIndex: any(named: 'initialIndex'),
+                  initialPosition: any(named: 'initialPosition'),
+                  preload: any(named: 'preload'),
+                  shuffleOrder: captureAny(named: 'shuffleOrder'),
+                ),
+              ).captured.single
+              as QueueShuffleOrder;
+      order.indices.addAll([2, 0, 1]);
+
+      await target.replace(1, trackWith());
+
+      expect(order.nextInsertPosition, 2);
     });
   });
 

--- a/test/domain/providers/forward_cache_provider_test.dart
+++ b/test/domain/providers/forward_cache_provider_test.dart
@@ -1,0 +1,671 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/main.dart';
+import 'package:jplayer/src/core/audio/stream_target_profile.dart';
+import 'package:jplayer/src/core/downloads/cache_downloader.dart';
+import 'package:jplayer/src/core/enums/enums.dart';
+import 'package:jplayer/src/data/backend/media_server_client.dart';
+import 'package:jplayer/src/data/backend/playback_report.dart';
+import 'package:jplayer/src/data/backend/stream_source.dart';
+import 'package:jplayer/src/data/providers/providers.dart';
+import 'package:jplayer/src/data/services/queue_cache_service.dart';
+import 'package:jplayer/src/data/storages/download_database.dart';
+import 'package:jplayer/src/data/storages/queue_cache_database.dart';
+import 'package:jplayer/src/domain/models/models.dart';
+import 'package:jplayer/src/domain/playback/playback_target.dart';
+import 'package:jplayer/src/domain/playback/playback_target_provider.dart';
+import 'package:jplayer/src/domain/providers/app_settings_provider.dart';
+import 'package:jplayer/src/domain/providers/forward_cache_provider.dart';
+import 'package:jplayer/src/domain/providers/playback_provider.dart';
+import 'package:jplayer/src/providers/connectivity_provider.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:path/path.dart' hide equals;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class _FakeTarget implements PlaybackTarget, SwappableQueue {
+  _FakeTarget({this.kind = PlaybackTargetKind.local});
+
+  final _controller = StreamController<TargetPlaybackState>.broadcast();
+
+  final loaded = <List<TargetTrack>>[];
+  final replaced = <(int, TargetTrack)>[];
+
+  TargetPlaybackState _state = TargetPlaybackState.idle;
+
+  @override
+  final PlaybackTargetKind kind;
+
+  @override
+  String get id => 'local';
+
+  @override
+  String get name => 'This device';
+
+  @override
+  StreamTargetProfile get streamProfile =>
+      StreamTargetProfile.localPlayer(isAndroid: false);
+
+  @override
+  bool get supportsLocalFiles => kind == PlaybackTargetKind.local;
+
+  @override
+  TargetPlaybackState get state => _state;
+
+  @override
+  Stream<TargetPlaybackState> get stateStream => _controller.stream;
+
+  void fail() {
+    _state = TargetPlaybackState(
+      status: PlaybackStatus.error,
+      position: _state.position,
+      currentIndex: _state.currentIndex,
+    );
+    _controller.add(_state);
+  }
+
+  void moveTo(int index) {
+    _state = TargetPlaybackState(
+      status: PlaybackStatus.playing,
+      position: Duration.zero,
+      currentIndex: index,
+    );
+    _controller.add(_state);
+  }
+
+  @override
+  Future<void> load(
+    List<TargetTrack> tracks, {
+    required int initialIndex,
+    required Duration initialPosition,
+    required bool autoPlay,
+  }) async {
+    loaded.add(tracks);
+  }
+
+  @override
+  Future<void> replace(int index, TargetTrack track) async =>
+      replaced.add((index, track));
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> dispose() async => _controller.close();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+class _FakeDownloader implements CacheDownloader {
+  _FakeDownloader(this._directory);
+
+  final Directory _directory;
+  final requested = <String>[];
+  final cancelled = <String>[];
+  final _hanging = <String, Completer<String?>>{};
+
+  int bytes = 1024;
+  bool hang = false;
+
+  @override
+  Future<String> directoryPath() async => _directory.path;
+
+  @override
+  Future<String?> fetch({
+    required String id,
+    required String url,
+    required String fileName,
+  }) async {
+    requested.add(id);
+    if (hang) {
+      final completer = Completer<String?>();
+      _hanging[id] = completer;
+      return completer.future;
+    }
+    return _write(fileName);
+  }
+
+  String _write(String fileName) {
+    final file = File(join(_directory.path, fileName));
+    file.openSync(mode: FileMode.write)
+      ..truncateSync(bytes)
+      ..closeSync();
+    return file.path;
+  }
+
+  @override
+  Future<void> cancel(String id) async {
+    cancelled.add(id);
+    _hanging.remove(id)?.complete(null);
+  }
+}
+
+class _HookedDownloadDatabase extends DownloadDatabase {
+
+  Future<void> Function()? onNextLookup;
+
+  @override
+  Future<bool> isSongDownloaded(String id) async {
+    final hook = onNextLookup;
+    if (hook != null) {
+      onNextLookup = null;
+      await hook();
+    }
+    return super.isSongDownloaded(id);
+  }
+}
+
+class _MockMediaServerClient extends Mock implements MediaServerClient {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+
+  late Directory filesDir;
+  late ProviderContainer container;
+  late _FakeTarget target;
+  late _FakeDownloader downloader;
+  late MediaServerClient client;
+
+  const album = LibraryItem(
+    id: 'album',
+    name: 'Album',
+    kind: ItemKind.album,
+  );
+  final songs = [
+    for (final id in ['a', 'b', 'c'])
+      LibraryItem(
+        id: id,
+        name: 'song $id',
+        kind: ItemKind.song,
+        duration: const Duration(minutes: 5),
+      ),
+  ];
+
+  setUpAll(() async {
+    final dbDir = await Directory.systemTemp.createTemp('forward_cache_db');
+    await databaseFactory.setDatabasesPath(dbDir.path);
+    registerFallbackValue(songs.first);
+    registerFallbackValue(StreamTargetProfile.download(isAndroid: false));
+    registerFallbackValue(
+      const PlaybackReport(itemId: 'fallback', playSessionId: 'fallback'),
+    );
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    deviceId = 'test-device';
+    filesDir = await Directory.systemTemp.createTemp('forward_cache');
+    final dir = await getDatabasesPath();
+    await databaseFactory.deleteDatabase(join(dir, 'downloads.db'));
+
+    target = _FakeTarget();
+    downloader = _FakeDownloader(filesDir);
+    client = _MockMediaServerClient();
+    when(
+      () => client.resolveStreamSource(
+        any(),
+        playSessionId: any(named: 'playSessionId'),
+        target: any(named: 'target'),
+      ),
+    ).thenAnswer(
+      (_) async => StreamSource(
+        uri: Uri.parse('http://server/audio/stream'),
+        isHls: false,
+        outputContainer: 'flac',
+        mimeType: 'audio/flac',
+      ),
+    );
+    when(() => client.reportPlaybackStarted(any())).thenAnswer((_) async {});
+    when(() => client.reportPlaybackStopped(any())).thenAnswer((_) async {});
+    when(() => client.reportPlaybackProgress(any())).thenAnswer((_) async {});
+  });
+
+  tearDown(() async {
+    await container.read(playbackProvider.notifier).clear();
+    container.dispose();
+    if (filesDir.existsSync()) await filesDir.delete(recursive: true);
+  });
+
+  List<Override> overridesFor(
+    ForwardCacheLimit limit, {
+    DownloadDatabase? downloads,
+    ForwardCacheWindow window = ForwardCacheWindow.min30,
+  }) => [
+    localPlaybackTargetProvider.overrideWithValue(target),
+    mediaServerClientProvider.overrideWith((_) => client),
+    isOfflineProvider.overrideWithValue(false),
+    forwardCacheLimitProvider.overrideWithValue(limit),
+    forwardCacheWindowProvider.overrideWithValue(window),
+    if (downloads != null)
+      downloadDatabaseProvider.overrideWithValue(downloads),
+    queueCacheServiceProvider.overrideWith(
+      (ref) => QueueCacheService(
+        database: ref.watch(queueCacheDatabaseProvider),
+        downloader: downloader,
+        deviceId: 'test-device',
+      ),
+    ),
+  ];
+
+  ProviderContainer containerWith(
+    ForwardCacheLimit limit, {
+    DownloadDatabase? downloads,
+    ForwardCacheWindow window = ForwardCacheWindow.min30,
+  }) => container = ProviderContainer(
+    overrides: overridesFor(limit, downloads: downloads, window: window),
+  );
+
+  Future<void> pumpUntil(
+    bool Function() done, {
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    while (!done() && DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+  }
+
+  Future<void> pumpUntilAsync(
+    Future<bool> Function() done, {
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    while (!await done() && DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+  }
+
+  Future<void> settle() =>
+      Future<void>.delayed(const Duration(milliseconds: 300));
+
+  group('ForwardCacheNotifier', () {
+    test('- fetches ahead of the playhead, current track last', () async {
+      containerWith(ForwardCacheLimit.gb1);
+      container.read(forwardCacheProvider.notifier);
+
+      await container
+          .read(playbackProvider.notifier)
+          .play(songs[1], songs, album);
+      await pumpUntil(() => container.read(forwardCacheProvider).length == 2);
+      await settle();
+
+      expect(downloader.requested, ['c', 'b']);
+      expect(container.read(forwardCacheProvider), {'b', 'c'});
+      expect(downloader.requested, isNot(contains('a')));
+    });
+
+    test('- caches nothing while the limit is off', () async {
+      containerWith(ForwardCacheLimit.off);
+      container.read(forwardCacheProvider.notifier);
+
+      await container
+          .read(playbackProvider.notifier)
+          .play(songs.first, songs, album);
+      await pumpUntil(() => downloader.requested.isNotEmpty);
+
+      expect(downloader.requested, isEmpty);
+    });
+
+    test('- caches nothing while casting', () async {
+      target = _FakeTarget(kind: PlaybackTargetKind.upnp);
+      containerWith(ForwardCacheLimit.gb1);
+      container.read(forwardCacheProvider.notifier);
+
+      await container
+          .read(playbackProvider.notifier)
+          .play(songs.first, songs, album);
+      await pumpUntil(() => downloader.requested.isNotEmpty);
+
+      expect(downloader.requested, isEmpty);
+    });
+
+    test('- swaps cached files into the queue behind the player', () async {
+      containerWith(ForwardCacheLimit.gb1);
+      container.read(forwardCacheProvider.notifier);
+
+      await container
+          .read(playbackProvider.notifier)
+          .play(songs.first, songs, album);
+      await pumpUntil(() => target.replaced.length == 2);
+
+      expect([for (final entry in target.replaced) entry.$1], [1, 2]);
+      expect(
+        [for (final entry in target.replaced) entry.$2.itemId],
+        ['b', 'c'],
+      );
+      expect(
+        target.replaced.every((entry) => entry.$2.isLocalFile),
+        isTrue,
+      );
+    });
+
+    test('- swaps the track it was playing once playback moves on', () async {
+      containerWith(ForwardCacheLimit.gb1);
+      container.read(forwardCacheProvider.notifier);
+
+      await container
+          .read(playbackProvider.notifier)
+          .play(songs.first, songs, album);
+      await pumpUntil(() => target.replaced.length == 2);
+      expect(
+        [for (final entry in target.replaced) entry.$2.itemId],
+        isNot(contains('a')),
+      );
+
+      target.moveTo(1);
+      await pumpUntil(
+        () => target.replaced.any((entry) => entry.$2.itemId == 'a'),
+      );
+
+      final adopted = target.replaced.lastWhere(
+        (entry) => entry.$2.itemId == 'a',
+      );
+      expect(adopted.$1, 0);
+      expect(adopted.$2.isLocalFile, isTrue);
+    });
+
+    test('- keeps the playing queue when the limit is switched off', () async {
+      containerWith(ForwardCacheLimit.gb1);
+      container.read(forwardCacheProvider.notifier);
+      await container
+          .read(playbackProvider.notifier)
+          .play(songs.first, songs, album);
+      await pumpUntil(() => container.read(forwardCacheProvider).length == 3);
+
+      container.updateOverrides(overridesFor(ForwardCacheLimit.off));
+      await settle();
+
+      final database = container.read(queueCacheDatabaseProvider);
+      expect(await database.cachedIds(), {'a', 'b', 'c'});
+
+      const other = LibraryItem(
+        id: 'd',
+        name: 'song d',
+        kind: ItemKind.song,
+      );
+      await container
+          .read(playbackProvider.notifier)
+          .play(other, const [other], album);
+      await pumpUntilAsync(() async => (await database.cachedIds()).isEmpty);
+
+      expect(await database.cachedIds(), isEmpty);
+    });
+
+    test('- evicts the old queue so a new one can still cache', () async {
+      containerWith(ForwardCacheLimit.mb500);
+      downloader.bytes = 300 * 1024 * 1024;
+      container.read(forwardCacheProvider.notifier);
+
+      await container
+          .read(playbackProvider.notifier)
+          .play(songs.first, songs, album);
+      await pumpUntil(() => container.read(forwardCacheProvider).length == 2);
+
+      const next = LibraryItem(id: 'd', name: 'song d', kind: ItemKind.song);
+      await container
+          .read(playbackProvider.notifier)
+          .play(next, const [next], album);
+      await pumpUntil(
+        () => container.read(forwardCacheProvider).contains('d'),
+      );
+
+      expect(container.read(forwardCacheProvider), contains('d'));
+      expect(container.read(forwardCacheProvider), isNot(contains('a')));
+    });
+
+    test('- caches again after the OS reclaims the files', () async {
+      containerWith(ForwardCacheLimit.mb500);
+      downloader.bytes = 300 * 1024 * 1024;
+      container.read(forwardCacheProvider.notifier);
+
+      await container
+          .read(playbackProvider.notifier)
+          .play(songs.first, songs, album);
+      await pumpUntil(() => container.read(forwardCacheProvider).length == 2);
+      for (final file in filesDir.listSync().whereType<File>()) {
+        file.deleteSync();
+      }
+
+      downloader.bytes = 1024;
+      target.moveTo(1);
+      await pumpUntil(
+        () => container.read(forwardCacheProvider).contains('c'),
+      );
+
+      expect(container.read(forwardCacheProvider), contains('c'));
+    });
+
+    test('- only fetches as far ahead as the window allows', () async {
+      containerWith(ForwardCacheLimit.gb1, window: ForwardCacheWindow.min10);
+      container.read(forwardCacheProvider.notifier);
+
+      await container
+          .read(playbackProvider.notifier)
+          .play(songs.first, songs, album);
+      await pumpUntil(() => container.read(forwardCacheProvider).length == 2);
+      await settle();
+
+      expect(container.read(forwardCacheProvider), {'a', 'b'});
+      expect(downloader.requested, isNot(contains('c')));
+    });
+
+    test('- pulls in the next track as playback advances', () async {
+      containerWith(ForwardCacheLimit.gb1, window: ForwardCacheWindow.min10);
+      container.read(forwardCacheProvider.notifier);
+
+      await container
+          .read(playbackProvider.notifier)
+          .play(songs.first, songs, album);
+      await pumpUntil(() => container.read(forwardCacheProvider).length == 2);
+
+      target.moveTo(1);
+      await pumpUntil(
+        () => container.read(forwardCacheProvider).contains('c'),
+      );
+
+      expect(container.read(forwardCacheProvider), {'a', 'b', 'c'});
+    });
+
+    test('- keeps played tracks while there is room', () async {
+      containerWith(ForwardCacheLimit.gb1, window: ForwardCacheWindow.min10);
+      container.read(forwardCacheProvider.notifier);
+
+      await container
+          .read(playbackProvider.notifier)
+          .play(songs.first, songs, album);
+      await pumpUntil(() => container.read(forwardCacheProvider).length == 2);
+
+      target.moveTo(2);
+      await pumpUntil(
+        () => container.read(forwardCacheProvider).contains('c'),
+      );
+
+      expect(container.read(forwardCacheProvider), {'a', 'b', 'c'});
+    });
+
+    test('- evicts what was played long ago to keep filling', () async {
+      final longQueue = [
+        for (final id in ['a', 'b', 'c', 'd', 'e', 'f'])
+          LibraryItem(
+            id: id,
+            name: 'song $id',
+            kind: ItemKind.song,
+            duration: const Duration(minutes: 5),
+          ),
+      ];
+      containerWith(ForwardCacheLimit.mb500, window: ForwardCacheWindow.min10);
+      downloader.bytes = 300 * 1024 * 1024;
+      container.read(forwardCacheProvider.notifier);
+
+      await container
+          .read(playbackProvider.notifier)
+          .play(longQueue.first, longQueue, album);
+      await pumpUntil(() => container.read(forwardCacheProvider).length == 2);
+      expect(container.read(forwardCacheProvider), {'a', 'b'});
+
+      target.moveTo(4);
+      await pumpUntil(
+        () => container.read(forwardCacheProvider).contains('e'),
+      );
+
+      expect(container.read(forwardCacheProvider), contains('e'));
+      expect(container.read(forwardCacheProvider), isNot(contains('a')));
+    });
+
+    test('- cancels an in-flight fetch when asked to stop', () async {
+      containerWith(ForwardCacheLimit.gb1);
+      downloader.hang = true;
+      final notifier = container.read(forwardCacheProvider.notifier);
+
+      await container
+          .read(playbackProvider.notifier)
+          .play(songs.first, songs, album);
+      await pumpUntil(() => downloader.requested.isNotEmpty);
+
+      await notifier.cancelPending();
+      final requested = downloader.requested.length;
+      await settle();
+
+      expect(downloader.cancelled, contains('b'));
+      expect(await container.read(queueCacheDatabaseProvider).cachedIds(),
+          isEmpty);
+      expect(downloader.requested, hasLength(requested));
+    });
+
+    test('- cancels an in-flight fetch when switched off', () async {
+      containerWith(ForwardCacheLimit.gb1);
+      downloader.hang = true;
+      container.read(forwardCacheProvider.notifier);
+
+      await container
+          .read(playbackProvider.notifier)
+          .play(songs.first, songs, album);
+      await pumpUntil(() => downloader.requested.isNotEmpty);
+
+      container.updateOverrides(overridesFor(ForwardCacheLimit.off));
+      await pumpUntil(() => downloader.cancelled.isNotEmpty);
+
+      expect(downloader.cancelled, contains('b'));
+    });
+
+    test('- starts a fresh queue straight from the cache', () async {
+      containerWith(ForwardCacheLimit.gb1);
+      container.read(forwardCacheProvider.notifier);
+
+      await container
+          .read(playbackProvider.notifier)
+          .play(songs.first, songs, album);
+      await pumpUntil(() => container.read(forwardCacheProvider).length == 3);
+
+      await container
+          .read(playbackProvider.notifier)
+          .play(songs.first, songs, album);
+
+      final tracks = target.loaded.last;
+      expect(tracks.every((track) => track.isLocalFile), isTrue);
+    });
+  });
+
+  group('adoptCachedFiles', () {
+    late _HookedDownloadDatabase downloads;
+    late QueueCacheDatabase database;
+    late PlaybackNotifier playback;
+
+    setUp(() {
+      downloads = _HookedDownloadDatabase();
+      containerWith(ForwardCacheLimit.off, downloads: downloads);
+      database = container.read(queueCacheDatabaseProvider);
+      playback = container.read(playbackProvider.notifier);
+    });
+
+    Future<Map<String, String>> seedCache(List<LibraryItem> items) async {
+      final paths = <String, String>{};
+      for (final item in items) {
+        final file = File(join(filesDir.path, '${item.id}.flac'))
+          ..writeAsBytesSync(List.filled(16, 0));
+        await database.insert(item, file: file);
+        paths[item.id] = file.path;
+      }
+      return paths;
+    }
+
+    test('- swaps every queue entry but the playing one', () async {
+      await playback.play(songs.first, songs, album);
+      final paths = await seedCache([songs[1], songs[2]]);
+
+      await playback.adoptCachedFiles(paths);
+
+      expect([for (final entry in target.replaced) entry.$1], [1, 2]);
+    });
+
+    test('- runs one at a time when called concurrently', () async {
+      await playback.play(songs.first, songs, album);
+      final paths = await seedCache([songs[1], songs[2]]);
+
+      await Future.wait([
+        playback.adoptCachedFiles(paths),
+        playback.adoptCachedFiles(paths),
+      ]);
+
+      expect([for (final entry in target.replaced) entry.$1], [1, 2]);
+    });
+
+    test('- leaves a track that started playing mid-run alone', () async {
+      await playback.play(songs.first, songs, album);
+      final paths = await seedCache([songs[1], songs[2]]);
+      downloads.onNextLookup = () async {
+        target.moveTo(1);
+        await Future<void>.delayed(Duration.zero);
+      };
+
+      await playback.adoptCachedFiles(paths);
+
+      expect([for (final entry in target.replaced) entry.$1], [2]);
+    });
+
+    test('- restreams a track whose cached file vanished', () async {
+      await playback.play(songs.first, songs, album);
+      final paths = await seedCache([songs[1], songs[2]]);
+      await playback.adoptCachedFiles(paths);
+      target.moveTo(1);
+      await Future<void>.delayed(Duration.zero);
+      await File(paths['b']!).delete();
+      final loads = target.loaded.length;
+
+      target.fail();
+      await pumpUntil(() => target.loaded.length > loads);
+
+      final reloaded = target.loaded.last;
+      expect(reloaded[1].itemId, 'b');
+      expect(reloaded[1].uri.scheme, 'http');
+      expect(reloaded[2].uri.scheme, 'file');
+      expect(await database.cachedIds(), isNot(contains('b')));
+      expect(
+        container.read(playbackProvider).status,
+        isNot(PlaybackStatus.error),
+      );
+    });
+
+    test('- surfaces the error when the file is still there', () async {
+      await playback.play(songs.first, songs, album);
+      final paths = await seedCache([songs[1], songs[2]]);
+      await playback.adoptCachedFiles(paths);
+      target.moveTo(1);
+      await Future<void>.delayed(Duration.zero);
+
+      target.fail();
+      await pumpUntil(
+        () => container.read(playbackProvider).status == PlaybackStatus.error,
+      );
+
+      expect(container.read(playbackProvider).status, PlaybackStatus.error);
+    });
+  });
+}

--- a/test/domain/providers/forward_cache_provider_test.dart
+++ b/test/domain/providers/forward_cache_provider_test.dart
@@ -248,6 +248,7 @@ void main() {
     queueCacheServiceProvider.overrideWith(
       (ref) => QueueCacheService(
         database: ref.watch(queueCacheDatabaseProvider),
+        downloads: ref.watch(downloadDatabaseProvider),
         downloader: downloader,
         deviceId: 'test-device',
       ),


### PR DESCRIPTION
This PR adds new feature - forward caching. 
Forward caching is a way to download upcoming tracks so that they could be played when you're driving, or somewhere with bad internet connection(elevator, basement, just a building with concrete thick walls).

The way it works - it watches your current queue and downloads X minutes of upcoming tracks. This `x` value is configurable via settings menu. There are 2 settings for this - allowed space - from 500mb to 8gig, I recommend to set 1-2gig at max depending on your average file sizes. Another option - time to cache ahead - from 10 minutes to 60minutes

This means that when you start playing album or playlist - all the following songs will be cached as per your settings, so I would not set more than 15-20 mins of forward cache, otherwise you should expect huge traffic usage while initial caching happens. 15-20 mins gives you 4-5 songs on average and enough time for you to get back online so that player could download more tracks when you get better coverage. The settings you should set is strictly individual, depending on your conditions. By default its off, so this caching is purely opt-in

Cache eviction works very simple - when you start reach limit of allowed cache - app will remove oldest cached songs that arent present on current queue, so basically just rotate song from oldest played to newest played

This will also work in CarPlay app too, since playback wired through the same code.

In one of next PRs I will add a fallback, when app can replay cached songs in case if you stay without network longer than you have cache.