### PR TITLE
Discord activity

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_udid/flutter_udid.dart';
 import 'package:jplayer/src/app.dart';
 import 'package:jplayer/src/core/carplay/carplay_handler.dart';
+import 'package:jplayer/src/core/discord/discord_presence_handler.dart';
 import 'package:jplayer/src/core/downloads/download_paths.dart';
 import 'package:jplayer/src/core/errors/image_error_filter.dart';
 import 'package:jplayer/src/core/network/certificate_trust.dart';
@@ -137,6 +138,8 @@ Future<void> main() async {
   }
 
   if (Platform.isWindows) await SmtcHandler.initialize(container);
+
+  DiscordPresenceHandler.initialize(container);
 
   await SentryFlutter.init(
     (options) {

--- a/lib/src/config/constants.dart
+++ b/lib/src/config/constants.dart
@@ -6,3 +6,12 @@ const String version = '1.8.2';
 const String updatifyProjectId = '0ebf56de-26b5-4107-bc87-1aa89b328924';
 
 const String changelogTitle = "What's new";
+
+/// True for the direct-download (Developer ID / notarized DMG) build, set via
+/// `--dart-define=JELLYBOX_DIRECT_DOWNLOAD=true` in the macOS DMG workflow.
+/// Those builds are not sandboxed; the App Store build leaves this false.
+const bool kDirectDownloadBuild = bool.fromEnvironment(
+  'JELLYBOX_DIRECT_DOWNLOAD',
+);
+
+const String discordApplicationId = '1547587702344388712';

--- a/lib/src/core/discord/discord_activity.dart
+++ b/lib/src/core/discord/discord_activity.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+const discordListeningActivityType = 2;
+
+const _maxFieldBytes = 128;
+const _minFieldLength = 2;
+
+@immutable
+class DiscordActivity {
+  const DiscordActivity({
+    required this.details,
+    this.state,
+    this.largeImage,
+    this.largeText,
+    this.start,
+    this.end,
+  });
+
+  factory DiscordActivity.listening({
+    required String title,
+    String? artist,
+    String? album,
+    String? largeImage,
+    DateTime? start,
+    DateTime? end,
+  }) => DiscordActivity(
+    details: discordActivityField(title) ?? 'Unknown track',
+    state: discordActivityField(artist),
+    largeImage: largeImage,
+    largeText: discordActivityField(album),
+    start: start,
+    end: end,
+  );
+
+  final String details;
+  final String? state;
+  final String? largeImage;
+  final String? largeText;
+  final DateTime? start;
+  final DateTime? end;
+
+  Map<String, Object?> toJson() => {
+    'type': discordListeningActivityType,
+    'details': details,
+    'state': ?state,
+    if (largeImage case final image?)
+      'assets': {'large_image': image, 'large_text': ?largeText},
+    if (start != null || end != null)
+      'timestamps': {
+        if (start case final start?) 'start': start.millisecondsSinceEpoch,
+        if (end case final end?) 'end': end.millisecondsSinceEpoch,
+      },
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      other is DiscordActivity &&
+      other.details == details &&
+      other.state == state &&
+      other.largeImage == largeImage &&
+      other.largeText == largeText &&
+      other.start == start &&
+      other.end == end;
+
+  @override
+  int get hashCode =>
+      Object.hash(details, state, largeImage, largeText, start, end);
+}
+
+String? discordActivityField(String? value) {
+  final trimmed = value?.trim() ?? '';
+  if (trimmed.isEmpty) return null;
+
+  var runes = trimmed.runes.toList();
+  if (runes.length > _maxFieldBytes) {
+    runes = runes.sublist(0, _maxFieldBytes);
+  }
+  while (runes.isNotEmpty &&
+      utf8.encode(String.fromCharCodes(runes)).length > _maxFieldBytes) {
+    runes.removeLast();
+  }
+
+  final clipped = String.fromCharCodes(runes).trimRight();
+  if (clipped.isEmpty) return null;
+  return clipped.length < _minFieldLength
+      ? clipped.padRight(_minFieldLength)
+      : clipped;
+}

--- a/lib/src/core/discord/discord_frame.dart
+++ b/lib/src/core/discord/discord_frame.dart
@@ -1,0 +1,77 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+abstract final class DiscordOpcode {
+  static const handshake = 0;
+  static const frame = 1;
+  static const close = 2;
+  static const ping = 3;
+  static const pong = 4;
+}
+
+class DiscordFrame {
+  const DiscordFrame(this.opcode, this.payload);
+
+  final int opcode;
+  final Map<String, Object?> payload;
+}
+
+Uint8List encodeDiscordFrame(int opcode, Map<String, Object?> payload) {
+  final body = utf8.encode(jsonEncode(payload));
+  final frame = Uint8List(_headerLength + body.length);
+  ByteData.sublistView(frame, 0, _headerLength)
+    ..setUint32(0, opcode, Endian.little)
+    ..setUint32(4, body.length, Endian.little);
+  frame.setRange(_headerLength, frame.length, body);
+  return frame;
+}
+
+const int _headerLength = 8;
+const int _maxFrameLength = 1 << 20;
+
+class DiscordFrameReader {
+  Uint8List _buffer = Uint8List(0);
+
+  void reset() => _buffer = Uint8List(0);
+
+  List<DiscordFrame> add(List<int> chunk) {
+    if (chunk.isEmpty) return const [];
+    _buffer = Uint8List(_buffer.length + chunk.length)
+      ..setRange(0, _buffer.length, _buffer)
+      ..setRange(_buffer.length, _buffer.length + chunk.length, chunk);
+
+    final frames = <DiscordFrame>[];
+    var offset = 0;
+    while (_buffer.length - offset >= _headerLength) {
+      final header = ByteData.sublistView(
+        _buffer,
+        offset,
+        offset + _headerLength,
+      );
+      final opcode = header.getUint32(0, Endian.little);
+      final length = header.getUint32(4, Endian.little);
+      if (length > _maxFrameLength) {
+        throw FormatException('Discord frame too large: $length bytes');
+      }
+      if (_buffer.length - offset - _headerLength < length) break;
+
+      final start = offset + _headerLength;
+      final body = utf8.decode(
+        Uint8List.sublistView(_buffer, start, start + length),
+      );
+      offset = start + length;
+      frames.add(DiscordFrame(opcode, _decodePayload(body)));
+    }
+
+    _buffer = offset == 0
+        ? _buffer
+        : Uint8List.fromList(_buffer.sublist(offset));
+    return frames;
+  }
+}
+
+Map<String, Object?> _decodePayload(String body) {
+  if (body.isEmpty) return const {};
+  final decoded = jsonDecode(body);
+  return decoded is Map<String, Object?> ? decoded : const {};
+}

--- a/lib/src/core/discord/discord_pipe_transport.dart
+++ b/lib/src/core/discord/discord_pipe_transport.dart
@@ -1,0 +1,224 @@
+import 'dart:async';
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+import 'package:flutter/foundation.dart';
+import 'package:jplayer/src/core/discord/discord_transport.dart';
+
+typedef CreateFileWNative =
+    Pointer<Void> Function(
+      Pointer<Utf16>,
+      Uint32,
+      Uint32,
+      Pointer<Void>,
+      Uint32,
+      Uint32,
+      Pointer<Void>,
+    );
+typedef CreateFileWDart =
+    Pointer<Void> Function(
+      Pointer<Utf16>,
+      int,
+      int,
+      Pointer<Void>,
+      int,
+      int,
+      Pointer<Void>,
+    );
+
+typedef FileIoNative =
+    Int32 Function(
+      Pointer<Void>,
+      Pointer<Uint8>,
+      Uint32,
+      Pointer<Uint32>,
+      Pointer<Void>,
+    );
+typedef FileIoDart =
+    int Function(
+      Pointer<Void>,
+      Pointer<Uint8>,
+      int,
+      Pointer<Uint32>,
+      Pointer<Void>,
+    );
+
+typedef PeekNamedPipeNative =
+    Int32 Function(
+      Pointer<Void>,
+      Pointer<Uint8>,
+      Uint32,
+      Pointer<Uint32>,
+      Pointer<Uint32>,
+      Pointer<Uint32>,
+    );
+typedef PeekNamedPipeDart =
+    int Function(
+      Pointer<Void>,
+      Pointer<Uint8>,
+      int,
+      Pointer<Uint32>,
+      Pointer<Uint32>,
+      Pointer<Uint32>,
+    );
+
+typedef CloseHandleNative = Int32 Function(Pointer<Void>);
+typedef CloseHandleDart = int Function(Pointer<Void>);
+
+const _genericRead = 0x80000000;
+const _genericWrite = 0x40000000;
+const _openExisting = 3;
+const _invalidHandleAddress = -1;
+const _pollInterval = Duration(milliseconds: 250);
+
+final DynamicLibrary _kernel32 = DynamicLibrary.open('kernel32.dll');
+
+final CreateFileWDart _createFileW = _kernel32
+    .lookupFunction<CreateFileWNative, CreateFileWDart>('CreateFileW');
+
+final FileIoDart _readFile = _kernel32.lookupFunction<FileIoNative, FileIoDart>(
+  'ReadFile',
+);
+
+final FileIoDart _writeFile = _kernel32
+    .lookupFunction<FileIoNative, FileIoDart>('WriteFile');
+
+final PeekNamedPipeDart _peekNamedPipe = _kernel32
+    .lookupFunction<PeekNamedPipeNative, PeekNamedPipeDart>('PeekNamedPipe');
+
+final CloseHandleDart _closeHandle = _kernel32
+    .lookupFunction<CloseHandleNative, CloseHandleDart>('CloseHandle');
+
+class DiscordPipeException implements Exception {
+  const DiscordPipeException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'DiscordPipeException: $message';
+}
+
+Future<DiscordTransport?> openDiscordPipeTransport() async {
+  for (var index = 0; index < 10; index++) {
+    final path =
+        r'\\.\pipe\discord-ipc-'
+        '$index';
+    final name = path.toNativeUtf16();
+    try {
+      final handle = _createFileW(
+        name,
+        _genericRead | _genericWrite,
+        0,
+        nullptr,
+        _openExisting,
+        0,
+        nullptr,
+      );
+      if (handle.address != _invalidHandleAddress) {
+        return _PipeTransport(handle);
+      }
+    } on Object catch (error) {
+      debugPrint('[Discord] named pipe unavailable: $error');
+      return null;
+    } finally {
+      calloc.free(name);
+    }
+  }
+  return null;
+}
+
+class _PipeTransport implements DiscordTransport {
+  _PipeTransport(this._handle) {
+    _poll = Timer.periodic(_pollInterval, (_) => _drain());
+  }
+
+  final Pointer<Void> _handle;
+  final _incoming = StreamController<List<int>>();
+
+  late final Timer _poll;
+  var _closed = false;
+
+  @override
+  Stream<List<int>> get incoming => _incoming.stream;
+
+  @override
+  void send(List<int> data) {
+    if (_closed) throw const DiscordPipeException('pipe is closed');
+
+    final buffer = calloc<Uint8>(data.length);
+    final written = calloc<Uint32>();
+    try {
+      buffer.asTypedList(data.length).setAll(0, data);
+      if (_writeFile(_handle, buffer, data.length, written, nullptr) == 0) {
+        throw const DiscordPipeException('write failed');
+      }
+    } finally {
+      calloc
+        ..free(buffer)
+        ..free(written);
+    }
+  }
+
+  @override
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    _poll.cancel();
+    _release();
+    await _incoming.close();
+  }
+
+  void _drain() {
+    final available = calloc<Uint32>();
+    final read = calloc<Uint32>();
+    try {
+      while (!_closed) {
+        if (_peekNamedPipe(_handle, nullptr, 0, nullptr, available, nullptr) ==
+            0) {
+          _fail('peek failed');
+          return;
+        }
+        final pending = available.value;
+        if (pending == 0) return;
+
+        final buffer = calloc<Uint8>(pending);
+        try {
+          if (_readFile(_handle, buffer, pending, read, nullptr) == 0) {
+            _fail('read failed');
+            return;
+          }
+          final count = read.value;
+          if (count == 0) return;
+          _incoming.add(Uint8List.fromList(buffer.asTypedList(count)));
+        } finally {
+          calloc.free(buffer);
+        }
+      }
+    } on Object catch (error) {
+      _fail('$error');
+    } finally {
+      calloc
+        ..free(available)
+        ..free(read);
+    }
+  }
+
+  void _fail(String reason) {
+    if (_closed) return;
+    _closed = true;
+    _poll.cancel();
+    _release();
+    if (!_incoming.isClosed) {
+      _incoming.addError(DiscordPipeException(reason));
+      _incoming.close().ignore();
+    }
+  }
+
+  void _release() {
+    try {
+      _closeHandle(_handle);
+    } on Object catch (error) {
+      debugPrint('[Discord] closing named pipe failed: $error');
+    }
+  }
+}

--- a/lib/src/core/discord/discord_presence_client.dart
+++ b/lib/src/core/discord/discord_presence_client.dart
@@ -1,0 +1,222 @@
+import 'dart:async';
+import 'dart:io' show pid;
+
+import 'package:flutter/foundation.dart';
+import 'package:jplayer/src/core/discord/discord_activity.dart';
+import 'package:jplayer/src/core/discord/discord_frame.dart';
+import 'package:jplayer/src/core/discord/discord_transport.dart';
+
+class DiscordPresenceClient {
+  DiscordPresenceClient({
+    required this.applicationId,
+    Future<DiscordTransport?> Function() connect = openDiscordTransport,
+    int sendBudget = _defaultSendBudget,
+    Duration sendWindow = _defaultSendWindow,
+    List<Duration> retryDelays = _defaultRetryDelays,
+  }) : _connect = connect,
+       _sendBudget = sendBudget,
+       _sendWindow = sendWindow,
+       _retryDelays = retryDelays;
+
+  static const _defaultSendBudget = 4;
+  static const _defaultSendWindow = Duration(seconds: 20);
+  static const _fatalCloseCodes = {4000, 4002, 4005, 4006};
+
+  static const _defaultRetryDelays = [
+    Duration(seconds: 5),
+    Duration(seconds: 20),
+    Duration(seconds: 60),
+  ];
+
+  final String applicationId;
+
+  final Future<DiscordTransport?> Function() _connect;
+  final int _sendBudget;
+  final Duration _sendWindow;
+  final List<Duration> _retryDelays;
+  final _sendTimes = <DateTime>[];
+  final _reader = DiscordFrameReader();
+
+  DiscordTransport? _transport;
+  StreamSubscription<List<int>>? _subscription;
+  Timer? _retry;
+  Timer? _throttle;
+  DiscordActivity? _desired;
+  DiscordActivity? _sent;
+  var _attempt = 0;
+  var _ready = false;
+  var _started = false;
+  var _nonce = 0;
+
+  bool get isReady => _ready;
+
+  void start() {
+    if (_started) return;
+    _started = true;
+    unawaited(_open());
+  }
+
+  void setActivity(DiscordActivity? activity) {
+    if (activity == _desired) return;
+    _desired = activity;
+    _flush();
+  }
+
+  Future<void> stop() async {
+    _started = false;
+    _retry?.cancel();
+    _throttle?.cancel();
+    _retry = null;
+    _throttle = null;
+    if (_ready && _desired != null) _sendActivity(null);
+    _desired = null;
+    _sendTimes.clear();
+    _attempt = 0;
+    await _teardown();
+  }
+
+  Future<void> _open() async {
+    if (!_started || _transport != null) return;
+
+    DiscordTransport? transport;
+    try {
+      transport = await _connect();
+    } on Object catch (error) {
+      debugPrint('[Discord] connect failed: $error');
+    }
+    if (transport == null) {
+      debugPrint(
+        '[Discord] no IPC socket found; is the desktop client running?',
+      );
+      _scheduleRetry();
+      return;
+    }
+    if (!_started) {
+      await transport.close();
+      return;
+    }
+
+    _transport = transport;
+    _reader.reset();
+    _ready = false;
+    _sent = null;
+    _subscription = transport.incoming.listen(
+      _onData,
+      onError: (Object error) {
+        debugPrint('[Discord] transport error: $error');
+        _reconnect();
+      },
+      onDone: _reconnect,
+      cancelOnError: true,
+    );
+    _send(DiscordOpcode.handshake, {'v': 1, 'client_id': applicationId});
+  }
+
+  void _onData(List<int> chunk) {
+    final List<DiscordFrame> frames;
+    try {
+      frames = _reader.add(chunk);
+    } on Object catch (error) {
+      debugPrint('[Discord] malformed frame: $error');
+      _reconnect();
+      return;
+    }
+
+    for (final frame in frames) {
+      switch (frame.opcode) {
+        case DiscordOpcode.ping:
+          _send(DiscordOpcode.pong, frame.payload);
+        case DiscordOpcode.close:
+          _onClose(frame.payload);
+          return;
+        case DiscordOpcode.frame:
+          _onCommand(frame.payload);
+      }
+    }
+  }
+
+  void _onClose(Map<String, Object?> payload) {
+    debugPrint('[Discord] connection closed: $payload');
+    if (_fatalCloseCodes.contains(payload['code'])) {
+      _started = false;
+      unawaited(_teardown());
+      return;
+    }
+    _reconnect();
+  }
+
+  void _onCommand(Map<String, Object?> payload) {
+    switch (payload['evt']) {
+      case 'READY':
+        _ready = true;
+        _attempt = 0;
+        _sent = null;
+        _flush();
+      case 'ERROR':
+        debugPrint('[Discord] rejected: ${payload['data']}');
+    }
+  }
+
+  void _flush() {
+    if (!_ready || _transport == null || _desired == _sent) return;
+
+    final now = DateTime.now();
+    _sendTimes.removeWhere((sent) => now.difference(sent) >= _sendWindow);
+    if (_sendTimes.length >= _sendBudget) {
+      final wait = _sendWindow - now.difference(_sendTimes.first);
+      _throttle ??= Timer(wait, () {
+        _throttle = null;
+        _flush();
+      });
+      return;
+    }
+
+    _sendTimes.add(now);
+    _sent = _desired;
+    _sendActivity(_desired);
+  }
+
+  void _sendActivity(DiscordActivity? activity) => _send(DiscordOpcode.frame, {
+    'cmd': 'SET_ACTIVITY',
+    'nonce': '${++_nonce}',
+    'args': {'pid': pid, 'activity': activity?.toJson()},
+  });
+
+  void _send(int opcode, Map<String, Object?> payload) {
+    final transport = _transport;
+    if (transport == null) return;
+    try {
+      transport.send(encodeDiscordFrame(opcode, payload));
+    } on Object catch (error) {
+      debugPrint('[Discord] send failed: $error');
+      _reconnect();
+    }
+  }
+
+  void _reconnect() => unawaited(_teardown().then((_) => _scheduleRetry()));
+
+  Future<void> _teardown() async {
+    final transport = _transport;
+    _transport = null;
+    _ready = false;
+    _sent = null;
+
+    try {
+      await _subscription?.cancel();
+      _subscription = null;
+      await transport?.close();
+    } on Object catch (error) {
+      debugPrint('[Discord] teardown failed: $error');
+    }
+  }
+
+  void _scheduleRetry() {
+    if (!_started || _retry != null || _transport != null) return;
+    final delay = _retryDelays[_attempt.clamp(0, _retryDelays.length - 1)];
+    _attempt++;
+    _retry = Timer(delay, () {
+      _retry = null;
+      unawaited(_open());
+    });
+  }
+}

--- a/lib/src/core/discord/discord_presence_handler.dart
+++ b/lib/src/core/discord/discord_presence_handler.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jplayer/src/config/constants.dart';
+import 'package:jplayer/src/core/discord/discord_activity.dart';
+import 'package:jplayer/src/core/discord/discord_presence_client.dart';
+import 'package:jplayer/src/domain/models/models.dart';
+import 'package:jplayer/src/domain/providers/app_settings_provider.dart';
+import 'package:jplayer/src/domain/providers/now_playing_provider.dart';
+import 'package:jplayer/src/domain/providers/playback_provider.dart';
+import 'package:just_audio_background/just_audio_background.dart'
+    show MediaItem;
+
+bool get supportsDiscordPresence {
+  if (kIsWeb) return false;
+  if (Platform.isMacOS) return kDirectDownloadBuild;
+  return Platform.isWindows || Platform.isLinux;
+}
+
+class DiscordPresenceHandler {
+  static const _artworkAsset = 'jellybox';
+  static const _seekTolerance = Duration(seconds: 4);
+
+  static DiscordPresenceClient? _client;
+  static ProviderContainer? _container;
+  static String? _timelineId;
+  static DateTime? _timelineStart;
+  static DateTime? _timelineEnd;
+
+  static void initialize(
+    ProviderContainer ref, {
+    DiscordPresenceClient? client,
+  }) {
+    if (_client != null) return;
+    if (client == null && !supportsDiscordPresence) return;
+
+    _container = ref;
+    _client =
+        client ?? DiscordPresenceClient(applicationId: discordApplicationId);
+
+    ref
+      ..listen(
+        settingProvider(AppSetting.discordRichPresence),
+        fireImmediately: true,
+        (previous, next) => _onEnabledChanged(enabled: next),
+      )
+      ..listen(nowPlayingProvider, (previous, next) => _update())
+      ..listen(playbackProvider, (previous, next) => _update());
+  }
+
+  @visibleForTesting
+  static void reset() {
+    _client = null;
+    _container = null;
+    _resetTimeline();
+  }
+
+  static void _onEnabledChanged({required bool enabled}) {
+    final client = _client;
+    if (client == null) return;
+
+    if (enabled) {
+      client.start();
+      _update();
+    } else {
+      _resetTimeline();
+      unawaited(client.stop());
+    }
+  }
+
+  static void _update() {
+    final client = _client;
+    final container = _container;
+    if (client == null || container == null) return;
+    if (!container.read(settingProvider(AppSetting.discordRichPresence))) {
+      return;
+    }
+
+    client.setActivity(
+      _activityFor(
+        container.read(nowPlayingProvider),
+        container.read(playbackProvider),
+      ),
+    );
+  }
+
+  static DiscordActivity? _activityFor(MediaItem? song, PlaybackState state) {
+    if (song == null || !_isAudible(song, state)) {
+      _resetTimeline();
+      return null;
+    }
+
+    final timeline = _timelineFor(song, state);
+    return DiscordActivity.listening(
+      title: song.title,
+      artist: song.artist,
+      album: song.album,
+      largeImage: _artworkAsset,
+      start: timeline.start,
+      end: timeline.end,
+    );
+  }
+
+  static bool _isAudible(MediaItem song, PlaybackState state) =>
+      state.status == PlaybackStatus.playing ||
+      (state.status == PlaybackStatus.buffering && _timelineId == song.id);
+
+  static ({DateTime? start, DateTime? end}) _timelineFor(
+    MediaItem song,
+    PlaybackState state,
+  ) {
+    if (state.status == PlaybackStatus.buffering) {
+      return (start: _timelineStart, end: _timelineEnd);
+    }
+
+    final now = DateTime.now();
+    final start = _timelineStart;
+    if (_timelineId == song.id && start != null) {
+      final drift = now.difference(start) - state.position;
+      if (drift.abs() < _seekTolerance) {
+        return (start: start, end: _timelineEnd);
+      }
+    }
+
+    final anchor = now.subtract(state.position);
+    final duration = song.duration ?? state.totalDuration;
+    _timelineId = song.id;
+    _timelineStart = anchor;
+    _timelineEnd = duration == null ? null : anchor.add(duration);
+    return (start: _timelineStart, end: _timelineEnd);
+  }
+
+  static void _resetTimeline() {
+    _timelineId = null;
+    _timelineStart = null;
+    _timelineEnd = null;
+  }
+}

--- a/lib/src/core/discord/discord_transport.dart
+++ b/lib/src/core/discord/discord_transport.dart
@@ -1,0 +1,87 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:jplayer/src/core/discord/discord_pipe_transport.dart';
+
+abstract interface class DiscordTransport {
+  Stream<List<int>> get incoming;
+
+  void send(List<int> data);
+
+  Future<void> close();
+}
+
+Future<DiscordTransport?> openDiscordTransport() =>
+    Platform.isWindows ? openDiscordPipeTransport() : _openDiscordSocket();
+
+Future<DiscordTransport?> _openDiscordSocket() async {
+  for (final path in discordSocketPaths()) {
+    try {
+      final socket = await Socket.connect(
+        InternetAddress(path, type: InternetAddressType.unix),
+        0,
+        timeout: const Duration(seconds: 2),
+      );
+      return _SocketTransport(socket);
+    } on Object catch (_) {
+      continue;
+    }
+  }
+  return null;
+}
+
+const _sandboxDirectories = [
+  '',
+  'app/com.discordapp.Discord',
+  'app/com.discordapp.DiscordCanary',
+  'app/com.discordapp.DiscordPTB',
+  'snap.discord',
+  'snap.discord-canary',
+];
+
+Iterable<String> discordSocketPaths({Map<String, String>? environment}) {
+  final env = environment ?? Platform.environment;
+  final bases = <String>[
+    ?env['XDG_RUNTIME_DIR'],
+    ?env['TMPDIR'],
+    ?env['TMP'],
+    ?env['TEMP'],
+    '/tmp',
+  ];
+
+  final paths = <String>{};
+  for (final base in bases) {
+    final root = base.endsWith('/') ? base.substring(0, base.length - 1) : base;
+    if (root.isEmpty) continue;
+    for (final directory in _sandboxDirectories) {
+      final parent = directory.isEmpty ? root : '$root/$directory';
+      for (var index = 0; index < 10; index++) {
+        paths.add('$parent/discord-ipc-$index');
+      }
+    }
+  }
+  return paths;
+}
+
+class _SocketTransport implements DiscordTransport {
+  _SocketTransport(this._socket);
+
+  final Socket _socket;
+
+  @override
+  Stream<List<int>> get incoming => _socket;
+
+  @override
+  void send(List<int> data) => _socket.add(data);
+
+  @override
+  Future<void> close() async {
+    try {
+      await _socket.close();
+    } on Object catch (error) {
+      debugPrint('[Discord] socket close failed: $error');
+    }
+    _socket.destroy();
+  }
+}

--- a/lib/src/data/providers/secure_storage_provider.dart
+++ b/lib/src/data/providers/secure_storage_provider.dart
@@ -1,16 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:jplayer/src/config/constants.dart';
 
-/// True for the direct-download (Developer ID / notarized DMG) build, set via
-/// `--dart-define=JELLYBOX_DIRECT_DOWNLOAD=true` in the macOS DMG workflow.
-///
-/// Those builds are not sandboxed and carry no provisioning profile, so they
-/// cannot use the macOS Data Protection Keychain (which requires one). They use
-/// the legacy keychain instead, which needs neither a profile nor entitlements.
-/// The App Store build leaves this false and keeps the Data Protection Keychain.
-const bool _kDirectDownload = bool.fromEnvironment('JELLYBOX_DIRECT_DOWNLOAD');
-
-const AppleOptions _kMacOsOptions = _kDirectDownload
+/// Direct-download builds carry no provisioning profile, so they cannot use the
+/// macOS Data Protection Keychain (which requires one). They use the legacy
+/// keychain instead, which needs neither a profile nor entitlements. The App
+/// Store build keeps the Data Protection Keychain.
+const AppleOptions _kMacOsOptions = kDirectDownloadBuild
     ? MacOsOptions(usesDataProtectionKeychain: false)
     : MacOsOptions.defaultOptions;
 

--- a/lib/src/domain/providers/app_settings_provider.dart
+++ b/lib/src/domain/providers/app_settings_provider.dart
@@ -19,6 +19,7 @@ enum AppSetting {
   playerVolume('player_volume', defaultValue: 1.0),
   forwardCacheLimit('forward_cache_limit', defaultValue: 'off'),
   forwardCacheWindow('forward_cache_window', defaultValue: 'min30'),
+  discordRichPresence('discord_rich_presence'),
   rendererVolumes('renderer_volumes', defaultValue: <String, double>{});
 
   const AppSetting(this.key, {this.defaultValue = false});

--- a/lib/src/presentation/pages/settings_page.dart
+++ b/lib/src/presentation/pages/settings_page.dart
@@ -8,6 +8,7 @@ import 'package:go_router/go_router.dart';
 import 'package:jplayer/resources/j_player_icons.dart';
 import 'package:jplayer/src/config/constants.dart';
 import 'package:jplayer/src/config/routes.dart';
+import 'package:jplayer/src/core/discord/discord_presence_handler.dart';
 import 'package:jplayer/src/core/enums/enums.dart';
 import 'package:jplayer/src/domain/providers/providers.dart';
 import 'package:jplayer/src/presentation/themes/themes.dart';
@@ -212,6 +213,14 @@ class SettingsPage extends ConsumerWidget {
                         ref: ref,
                         setting: AppSetting.studioModeAnimation,
                         label: 'Enable Studio Mode animation',
+                      ),
+                    ],
+                    if (supportsDiscordPresence) ...[
+                      _sectionHeader('Discord'),
+                      _settingCheckbox(
+                        ref: ref,
+                        setting: AppSetting.discordRichPresence,
+                        label: 'Share what I am listening to on Discord',
                       ),
                     ],
                     if (!device.isDesktop) _logOutButton(ref),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -362,7 +362,7 @@ packages:
     source: hosted
     version: "0.2.3"
   ffi:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: ffi
       sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
@@ -794,10 +794,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -849,10 +849,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -1533,26 +1533,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.18"
   typed_data:
     dependency: transitive
     description:
@@ -1700,10 +1700,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   very_good_analysis:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: jplayer
 description: Jellyfin client
 publish_to: "none"
-version: 2.4.1+25
+version: 2.5.0+125
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
@@ -67,6 +67,7 @@ dependencies:
   connectivity_plus: ^7.3.1
   xml: ^6.6.1
   smtc_windows: ^1.1.0
+  ffi: ^2.2.0
   flutter_rust_bridge: 2.11.1 #do not update
 
 dev_dependencies:

--- a/test/core/discord/discord_activity_test.dart
+++ b/test/core/discord/discord_activity_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/core/discord/discord_activity.dart';
+
+void main() {
+  group('DiscordActivity.toJson', () {
+    test('describes a listening activity', () {
+      final start = DateTime.fromMillisecondsSinceEpoch(1000);
+      final end = DateTime.fromMillisecondsSinceEpoch(241000);
+      final activity = DiscordActivity.listening(
+        title: 'Bloom',
+        artist: 'Radiohead',
+        album: 'The King of Limbs',
+        largeImage: 'jellybox',
+        start: start,
+        end: end,
+      );
+
+      expect(activity.toJson(), {
+        'type': 2,
+        'details': 'Bloom',
+        'state': 'Radiohead',
+        'assets': {
+          'large_image': 'jellybox',
+          'large_text': 'The King of Limbs',
+        },
+        'timestamps': {'start': 1000, 'end': 241000},
+      });
+    });
+
+    test('omits absent artist, artwork and timestamps', () {
+      final activity = DiscordActivity.listening(title: 'Bloom');
+
+      expect(activity.toJson(), {'type': 2, 'details': 'Bloom'});
+    });
+
+    test('compares by value so repeat updates can be skipped', () {
+      final start = DateTime.fromMillisecondsSinceEpoch(1000);
+
+      expect(
+        DiscordActivity.listening(title: 'Bloom', artist: 'a', start: start),
+        DiscordActivity.listening(title: 'Bloom', artist: 'a', start: start),
+      );
+      expect(
+        DiscordActivity.listening(title: 'Bloom', start: start),
+        isNot(DiscordActivity.listening(title: 'Codex', start: start)),
+      );
+    });
+  });
+
+  group('discordActivityField', () {
+    test('drops empty values', () {
+      expect(discordActivityField(null), isNull);
+      expect(discordActivityField('   '), isNull);
+    });
+
+    test('pads a single character to the two Discord requires', () {
+      expect(discordActivityField('X'), 'X ');
+    });
+
+    test('clips long values to 128 bytes', () {
+      final field = discordActivityField('a' * 400);
+
+      expect(field, hasLength(128));
+    });
+
+    test('clips multi-byte values without splitting a rune', () {
+      final field = discordActivityField('é' * 100);
+
+      expect(field, isNotNull);
+      expect(field!.runes.every((rune) => rune == 'é'.runes.first), isTrue);
+      expect(field.runes.length, lessThanOrEqualTo(64));
+    });
+
+    test('keeps emoji intact', () {
+      final field = discordActivityField('🎵' * 40);
+
+      expect(field, isNotNull);
+      expect(field!.contains('�'), isFalse);
+      expect(field.runes.every((rune) => rune == '🎵'.runes.first), isTrue);
+    });
+  });
+}

--- a/test/core/discord/discord_frame_test.dart
+++ b/test/core/discord/discord_frame_test.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/core/discord/discord_frame.dart';
+
+void main() {
+  group('encodeDiscordFrame', () {
+    test('writes a little-endian opcode and length header', () {
+      final frame = encodeDiscordFrame(DiscordOpcode.handshake, {'v': 1});
+      final header = ByteData.sublistView(frame, 0, 8);
+      final body = utf8.decode(Uint8List.sublistView(frame, 8));
+
+      expect(header.getUint32(0, Endian.little), DiscordOpcode.handshake);
+      expect(header.getUint32(4, Endian.little), body.length);
+      expect(jsonDecode(body), {'v': 1});
+    });
+  });
+
+  group('DiscordFrameReader', () {
+    test('round-trips an encoded frame', () {
+      final reader = DiscordFrameReader();
+      final frames = reader.add(
+        encodeDiscordFrame(DiscordOpcode.frame, {'evt': 'READY'}),
+      );
+
+      expect(frames, hasLength(1));
+      expect(frames.single.opcode, DiscordOpcode.frame);
+      expect(frames.single.payload, {'evt': 'READY'});
+    });
+
+    test('waits for the rest of a frame split across chunks', () {
+      final reader = DiscordFrameReader();
+      final encoded = encodeDiscordFrame(DiscordOpcode.ping, {'nonce': 'abc'});
+
+      expect(reader.add(encoded.sublist(0, 4)), isEmpty);
+      expect(reader.add(encoded.sublist(4, 10)), isEmpty);
+
+      final frames = reader.add(encoded.sublist(10));
+      expect(frames, hasLength(1));
+      expect(frames.single.opcode, DiscordOpcode.ping);
+      expect(frames.single.payload, {'nonce': 'abc'});
+    });
+
+    test('returns every frame delivered in one chunk', () {
+      final reader = DiscordFrameReader();
+      final chunk = [
+        ...encodeDiscordFrame(DiscordOpcode.frame, {'evt': 'READY'}),
+        ...encodeDiscordFrame(DiscordOpcode.ping, {'ping': 1}),
+      ];
+
+      final frames = reader.add(chunk);
+      expect(frames.map((frame) => frame.opcode), [
+        DiscordOpcode.frame,
+        DiscordOpcode.ping,
+      ]);
+    });
+
+    test('keeps trailing bytes buffered for the next chunk', () {
+      final reader = DiscordFrameReader();
+      final first = encodeDiscordFrame(DiscordOpcode.frame, {'a': 1});
+      final second = encodeDiscordFrame(DiscordOpcode.frame, {'b': 2});
+
+      expect(reader.add([...first, ...second.sublist(0, 3)]), hasLength(1));
+      final frames = reader.add(second.sublist(3));
+      expect(frames.single.payload, {'b': 2});
+    });
+
+    test('rejects an implausibly large frame', () {
+      final reader = DiscordFrameReader();
+      final header = Uint8List(8);
+      ByteData.sublistView(header)
+        ..setUint32(0, DiscordOpcode.frame, Endian.little)
+        ..setUint32(4, 1 << 24, Endian.little);
+
+      expect(() => reader.add(header), throwsFormatException);
+    });
+
+    test('reset drops a partial frame left by a dead connection', () {
+      final reader = DiscordFrameReader();
+      final encoded = encodeDiscordFrame(DiscordOpcode.frame, {'a': 1});
+
+      expect(reader.add(encoded.sublist(0, 6)), isEmpty);
+      reader.reset();
+
+      final frames = reader.add(encoded);
+      expect(frames.single.payload, {'a': 1});
+    });
+  });
+}

--- a/test/core/discord/discord_ipc_live_test.dart
+++ b/test/core/discord/discord_ipc_live_test.dart
@@ -1,0 +1,52 @@
+@Tags(['discord'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/core/discord/discord_activity.dart';
+import 'package:jplayer/src/core/discord/discord_frame.dart';
+import 'package:jplayer/src/core/discord/discord_transport.dart';
+
+void main() {
+  test('the running Discord client answers our handshake', () async {
+    final transport = await openDiscordTransport();
+    if (transport == null) {
+      markTestSkipped('no Discord IPC socket; is the desktop client running?');
+      return;
+    }
+
+    final reader = DiscordFrameReader();
+    final frames = <DiscordFrame>[];
+    final subscription = transport.incoming.listen(
+      (chunk) => frames.addAll(reader.add(chunk)),
+    );
+
+    transport
+      ..send(
+        encodeDiscordFrame(DiscordOpcode.handshake, {
+          'v': 1,
+          'client_id': '000000000000000000',
+        }),
+      )
+      ..send(
+        encodeDiscordFrame(DiscordOpcode.frame, {
+          'cmd': 'SET_ACTIVITY',
+          'nonce': '1',
+          'args': {
+            'pid': 0,
+            'activity': DiscordActivity.listening(
+              title: 'Bloom',
+              artist: 'Radiohead',
+            ).toJson(),
+          },
+        }),
+      );
+
+    await Future<void>.delayed(const Duration(seconds: 2));
+    await subscription.cancel();
+    await transport.close();
+
+    printOnFailure('frames: ${frames.map((f) => '${f.opcode}:${f.payload}')}');
+    expect(frames, isNotEmpty);
+    expect(frames.first.payload, isNotEmpty);
+  });
+}

--- a/test/core/discord/discord_presence_client_test.dart
+++ b/test/core/discord/discord_presence_client_test.dart
@@ -1,0 +1,251 @@
+import 'dart:async';
+import 'dart:io' show SocketException;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/core/discord/discord_activity.dart';
+import 'package:jplayer/src/core/discord/discord_frame.dart';
+import 'package:jplayer/src/core/discord/discord_presence_client.dart';
+import 'package:jplayer/src/core/discord/discord_transport.dart';
+
+class _FakeTransport implements DiscordTransport {
+  final _controller = StreamController<List<int>>();
+  final _reader = DiscordFrameReader();
+  final sent = <DiscordFrame>[];
+
+  bool closed = false;
+
+  @override
+  Stream<List<int>> get incoming => _controller.stream;
+
+  @override
+  void send(List<int> data) => sent.addAll(_reader.add(data));
+
+  @override
+  Future<void> close() async {
+    closed = true;
+    if (!_controller.isClosed) await _controller.close();
+  }
+
+  void fail() => _controller.addError(const SocketException('dropped'));
+
+  void emit(int opcode, Map<String, Object?> payload) =>
+      _controller.add(encodeDiscordFrame(opcode, payload));
+
+  Future<void> becomeReady() async {
+    emit(DiscordOpcode.frame, {'cmd': 'DISPATCH', 'evt': 'READY'});
+    await pumpEventQueue();
+  }
+
+  List<DiscordFrame> get activities =>
+      sent.where((frame) => frame.payload['cmd'] == 'SET_ACTIVITY').toList();
+
+  Map<String, Object?>? get lastActivity {
+    final args = activities.last.payload['args']! as Map<String, Object?>;
+    return args['activity'] as Map<String, Object?>?;
+  }
+}
+
+void main() {
+  late _FakeTransport transport;
+  late DiscordPresenceClient client;
+
+  setUp(() {
+    transport = _FakeTransport();
+    client = DiscordPresenceClient(
+      applicationId: '1234567890',
+      connect: () async => transport,
+      sendBudget: 2,
+      sendWindow: const Duration(milliseconds: 60),
+    );
+  });
+
+  tearDown(() => client.stop());
+
+  Future<void> start() async {
+    client.start();
+    await pumpEventQueue();
+  }
+
+  test('handshakes with the application id', () async {
+    await start();
+
+    expect(transport.sent, hasLength(1));
+    expect(transport.sent.single.opcode, DiscordOpcode.handshake);
+    expect(transport.sent.single.payload, {'v': 1, 'client_id': '1234567890'});
+  });
+
+  test('holds the activity until Discord reports READY', () async {
+    await start();
+    client.setActivity(DiscordActivity.listening(title: 'Bloom'));
+    await pumpEventQueue();
+
+    expect(transport.activities, isEmpty);
+    expect(client.isReady, isFalse);
+
+    await transport.becomeReady();
+
+    expect(client.isReady, isTrue);
+    expect(transport.lastActivity, containsPair('details', 'Bloom'));
+    expect(transport.lastActivity, containsPair('type', 2));
+  });
+
+  test('sends the process id alongside the activity', () async {
+    await start();
+    await transport.becomeReady();
+    client.setActivity(DiscordActivity.listening(title: 'Bloom'));
+    await pumpEventQueue();
+
+    final args = transport.activities.last.payload['args']!;
+    expect((args as Map<String, Object?>)['pid'], isA<int>());
+  });
+
+  test('answers a ping with a matching pong', () async {
+    await start();
+    await transport.becomeReady();
+
+    transport.emit(DiscordOpcode.ping, {'nonce': 'abc'});
+    await pumpEventQueue();
+
+    final pong = transport.sent.last;
+    expect(pong.opcode, DiscordOpcode.pong);
+    expect(pong.payload, {'nonce': 'abc'});
+  });
+
+  test('does not resend an unchanged activity', () async {
+    await start();
+    await transport.becomeReady();
+
+    client.setActivity(DiscordActivity.listening(title: 'Bloom'));
+    await pumpEventQueue();
+    client.setActivity(DiscordActivity.listening(title: 'Bloom'));
+    await pumpEventQueue();
+
+    expect(transport.activities, hasLength(1));
+  });
+
+  test('sends immediately while the budget lasts', () async {
+    await start();
+    await transport.becomeReady();
+
+    client.setActivity(DiscordActivity.listening(title: 'First'));
+    await pumpEventQueue();
+    client.setActivity(DiscordActivity.listening(title: 'Second'));
+    await pumpEventQueue();
+
+    expect(transport.activities, hasLength(2));
+    expect(transport.lastActivity, containsPair('details', 'Second'));
+  });
+
+  test('defers past the budget and sends only the latest state', () async {
+    await start();
+    await transport.becomeReady();
+
+    client
+      ..setActivity(DiscordActivity.listening(title: 'First'))
+      ..setActivity(DiscordActivity.listening(title: 'Second'));
+    await pumpEventQueue();
+    client
+      ..setActivity(DiscordActivity.listening(title: 'Third'))
+      ..setActivity(DiscordActivity.listening(title: 'Fourth'));
+    await pumpEventQueue();
+
+    expect(transport.activities, hasLength(2));
+    expect(transport.lastActivity, containsPair('details', 'Second'));
+
+    await Future<void>.delayed(const Duration(milliseconds: 90));
+
+    expect(transport.activities, hasLength(3));
+    expect(transport.lastActivity, containsPair('details', 'Fourth'));
+  });
+
+  test('clears the activity and closes the transport on stop', () async {
+    await start();
+    await transport.becomeReady();
+    client.setActivity(DiscordActivity.listening(title: 'Bloom'));
+    await pumpEventQueue();
+
+    await client.stop();
+
+    expect(transport.lastActivity, isNull);
+    expect(transport.closed, isTrue);
+    expect(client.isReady, isFalse);
+  });
+
+  test('stops retrying when Discord rejects the application id', () async {
+    var connections = 0;
+    client = DiscordPresenceClient(
+      applicationId: 'not-an-app',
+      connect: () async {
+        connections++;
+        return transport;
+      },
+      retryDelays: const [Duration(milliseconds: 10)],
+    );
+
+    await start();
+    transport.emit(DiscordOpcode.close, {
+      'code': 4000,
+      'message': 'Invalid Client ID',
+    });
+    await pumpEventQueue();
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+    await pumpEventQueue();
+
+    expect(connections, 1);
+    expect(transport.closed, isTrue);
+  });
+
+  test('reconnects when Discord closes for a transient reason', () async {
+    final reconnected = _FakeTransport();
+    var connections = 0;
+    client = DiscordPresenceClient(
+      applicationId: '1234567890',
+      connect: () async {
+        connections++;
+        return connections == 1 ? transport : reconnected;
+      },
+      retryDelays: const [Duration(milliseconds: 10)],
+    );
+
+    await start();
+    transport.emit(DiscordOpcode.close, {'code': 4003});
+    await pumpEventQueue();
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+    await pumpEventQueue();
+
+    expect(connections, 2);
+  });
+
+  test('reconnects and restores the activity when the socket drops', () async {
+    final reconnected = _FakeTransport();
+    var connections = 0;
+    client = DiscordPresenceClient(
+      applicationId: '1234567890',
+      connect: () async {
+        connections++;
+        return connections == 1 ? transport : reconnected;
+      },
+      retryDelays: const [Duration(milliseconds: 10)],
+    );
+
+    await start();
+    await transport.becomeReady();
+    client.setActivity(DiscordActivity.listening(title: 'Bloom'));
+    await pumpEventQueue();
+    expect(transport.activities, hasLength(1));
+
+    transport.fail();
+    await pumpEventQueue();
+    expect(client.isReady, isFalse);
+    expect(transport.closed, isTrue);
+
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+    await pumpEventQueue();
+    expect(connections, 2);
+    expect(reconnected.sent.first.opcode, DiscordOpcode.handshake);
+
+    await reconnected.becomeReady();
+
+    expect(reconnected.lastActivity, containsPair('details', 'Bloom'));
+  });
+}

--- a/test/core/discord/discord_presence_handler_test.dart
+++ b/test/core/discord/discord_presence_handler_test.dart
@@ -1,0 +1,228 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/core/discord/discord_frame.dart';
+import 'package:jplayer/src/core/discord/discord_presence_client.dart';
+import 'package:jplayer/src/core/discord/discord_presence_handler.dart';
+import 'package:jplayer/src/core/discord/discord_transport.dart';
+import 'package:jplayer/src/domain/models/models.dart';
+import 'package:jplayer/src/domain/providers/app_settings_provider.dart';
+import 'package:jplayer/src/domain/providers/playback_provider.dart';
+
+class _StubPlayback extends StateNotifier<PlaybackState>
+    implements PlaybackNotifier {
+  _StubPlayback() : super(PlaybackState.initial());
+
+  PlaybackState get current => state;
+
+  set current(PlaybackState next) => state = next;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeTransport implements DiscordTransport {
+  final _controller = StreamController<List<int>>();
+  final _reader = DiscordFrameReader();
+  final sent = <DiscordFrame>[];
+
+  @override
+  Stream<List<int>> get incoming => _controller.stream;
+
+  @override
+  void send(List<int> data) => sent.addAll(_reader.add(data));
+
+  @override
+  Future<void> close() async {
+    if (!_controller.isClosed) await _controller.close();
+  }
+
+  Future<void> becomeReady() async {
+    _controller.add(
+      encodeDiscordFrame(DiscordOpcode.frame, {
+        'cmd': 'DISPATCH',
+        'evt': 'READY',
+      }),
+    );
+    await pumpEventQueue();
+  }
+
+  List<Map<String, Object?>?> get activities => sent
+      .where((frame) => frame.payload['cmd'] == 'SET_ACTIVITY')
+      .map(
+        (frame) =>
+            (frame.payload['args']! as Map<String, Object?>)['activity']
+                as Map<String, Object?>?,
+      )
+      .toList();
+}
+
+void main() {
+  LibraryItem songNamed(String id, String name) => LibraryItem(
+    id: id,
+    name: name,
+    kind: ItemKind.song,
+    albumArtist: 'Portishead',
+    albumName: 'Dummy',
+    duration: const Duration(minutes: 3),
+  );
+
+  PlaybackState stateWith(PlaybackStatus status) => PlaybackState(
+    album: const LibraryItem(
+      id: 'album-1',
+      name: 'Dummy',
+      kind: ItemKind.album,
+    ),
+    songs: [songNamed('song-1', 'Sour Times')],
+    status: status,
+    position: Duration.zero,
+    cacheProgress: Duration.zero,
+    currentMediaIndex: 0,
+  );
+
+  late _StubPlayback playback;
+  late _FakeTransport transport;
+  late AppSettingsNotifier settings;
+  late ProviderContainer container;
+
+  setUp(() {
+    DiscordPresenceHandler.reset();
+    playback = _StubPlayback();
+    transport = _FakeTransport();
+    settings = AppSettingsNotifier(null);
+    container = ProviderContainer(
+      overrides: [
+        playbackProvider.overrideWith((ref) => playback),
+        appSettingsProvider.overrideWith((ref) => settings),
+      ],
+    );
+    addTearDown(container.dispose);
+    addTearDown(DiscordPresenceHandler.reset);
+
+    DiscordPresenceHandler.initialize(
+      container,
+      client: DiscordPresenceClient(
+        applicationId: 'test-app',
+        connect: () async => transport,
+        sendBudget: 1000,
+      ),
+    );
+  });
+
+  Future<void> enable() async {
+    settings.setEnabled(AppSetting.discordRichPresence, value: true);
+    await pumpEventQueue();
+    await transport.becomeReady();
+  }
+
+  test('stays off the socket until the setting is enabled', () async {
+    playback.current = stateWith(PlaybackStatus.playing);
+    await pumpEventQueue();
+
+    expect(transport.sent, isEmpty);
+  });
+
+  test('publishes the current track once enabled', () async {
+    playback.current = stateWith(PlaybackStatus.playing);
+    await pumpEventQueue();
+    await enable();
+
+    expect(transport.activities.last, containsPair('details', 'Sour Times'));
+    expect(transport.activities.last, containsPair('state', 'Portishead'));
+    expect(transport.activities.last, containsPair('type', 2));
+  });
+
+  test('publishes a track that starts after being enabled', () async {
+    await enable();
+    expect(transport.activities, isEmpty);
+
+    playback.current = stateWith(PlaybackStatus.playing);
+    await pumpEventQueue();
+
+    expect(transport.activities.last, containsPair('details', 'Sour Times'));
+  });
+
+  test('sends timestamps while playing', () async {
+    await enable();
+    playback.current = stateWith(PlaybackStatus.playing);
+    await pumpEventQueue();
+
+    expect(transport.activities.last, contains('timestamps'));
+  });
+
+  test('clears the activity when playback is paused', () async {
+    await enable();
+    playback.current = stateWith(PlaybackStatus.playing);
+    await pumpEventQueue();
+
+    playback.current = stateWith(PlaybackStatus.paused);
+    await pumpEventQueue();
+
+    expect(transport.activities.last, isNull);
+  });
+
+  test('republishes the track when playback resumes', () async {
+    await enable();
+    playback
+      ..current = stateWith(PlaybackStatus.playing)
+      ..current = stateWith(PlaybackStatus.paused);
+    await pumpEventQueue();
+
+    playback.current = stateWith(PlaybackStatus.playing);
+    await pumpEventQueue();
+
+    expect(transport.activities.last, containsPair('details', 'Sour Times'));
+    expect(transport.activities.last, contains('timestamps'));
+  });
+
+  test('keeps the presence up while a track buffers', () async {
+    await enable();
+    playback.current = stateWith(PlaybackStatus.playing);
+    await pumpEventQueue();
+    final published = transport.activities.length;
+
+    playback.current = stateWith(PlaybackStatus.buffering);
+    await pumpEventQueue();
+
+    expect(transport.activities, hasLength(published));
+  });
+
+  test('holds the timeline steady while the position ticks', () async {
+    await enable();
+    playback.current = stateWith(PlaybackStatus.playing);
+    await pumpEventQueue();
+    final published = transport.activities.length;
+
+    for (var second = 1; second < 4; second++) {
+      playback.current = stateWith(
+        PlaybackStatus.playing,
+      ).copyWith(position: Duration(seconds: second));
+      await pumpEventQueue();
+    }
+
+    expect(transport.activities, hasLength(published));
+  });
+
+  test('clears the activity when playback stops', () async {
+    await enable();
+    playback.current = stateWith(PlaybackStatus.playing);
+    await pumpEventQueue();
+
+    playback.current = PlaybackState.initial();
+    await pumpEventQueue();
+
+    expect(transport.activities.last, isNull);
+  });
+
+  test('clears the activity when the setting is switched off', () async {
+    await enable();
+    playback.current = stateWith(PlaybackStatus.playing);
+    await pumpEventQueue();
+
+    settings.setEnabled(AppSetting.discordRichPresence, value: false);
+    await pumpEventQueue();
+
+    expect(transport.activities.last, isNull);
+  });
+}

--- a/test/core/discord/discord_transport_test.dart
+++ b/test/core/discord/discord_transport_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/core/discord/discord_transport.dart';
+
+void main() {
+  group('discordSocketPaths', () {
+    test('probes ten sockets per directory', () {
+      final paths = discordSocketPaths(
+        environment: const {'XDG_RUNTIME_DIR': '/run/user/1000'},
+      );
+
+      expect(paths, contains('/run/user/1000/discord-ipc-0'));
+      expect(paths, contains('/run/user/1000/discord-ipc-9'));
+      expect(paths, isNot(contains('/run/user/1000/discord-ipc-10')));
+    });
+
+    test('covers flatpak and snap socket locations', () {
+      final paths = discordSocketPaths(
+        environment: const {'XDG_RUNTIME_DIR': '/run/user/1000'},
+      );
+
+      expect(
+        paths,
+        contains('/run/user/1000/app/com.discordapp.Discord/discord-ipc-0'),
+      );
+      expect(paths, contains('/run/user/1000/snap.discord/discord-ipc-0'));
+    });
+
+    test('always falls back to /tmp', () {
+      final paths = discordSocketPaths(environment: const {});
+
+      expect(paths, contains('/tmp/discord-ipc-0'));
+    });
+
+    test('normalises a trailing slash and de-duplicates directories', () {
+      final paths = discordSocketPaths(
+        environment: const {'TMPDIR': '/tmp/', 'TMP': '/tmp'},
+      );
+
+      expect(
+        paths.where((path) => path == '/tmp/discord-ipc-0'),
+        hasLength(1),
+      );
+    });
+  });
+}


### PR DESCRIPTION
This PR ads Discord activity integrtation for desktop apps. jellybox will share whats currently playing to discord. It will only work if your discord  settings enables activity sharing. It also does not work on mac appstore app, only on notarized DMG. There's not much I can do, since appstore apps are run in sandbox. Linux and windows are all good