### PR TITLE
Refactor api #2. Make it more generic

### DIFF
--- a/lib/src/core/carplay/carplay_handler.dart
+++ b/lib/src/core/carplay/carplay_handler.dart
@@ -3,6 +3,7 @@ import 'dart:io' show Platform;
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:jplayer/src/core/enums/enums.dart';
+import 'package:jplayer/src/data/backend/library_query.dart';
 import 'package:jplayer/src/data/providers/media_server_client_provider.dart';
 import 'package:jplayer/src/data/providers/search_provider.dart';
 import 'package:jplayer/src/domain/models/models.dart';
@@ -17,10 +18,10 @@ import 'package:jplayer/src/domain/providers/set_playback_provider.dart';
 import 'package:jplayer/src/domain/providers/todays_playlists_provider.dart';
 import 'package:jplayer/src/providers/auth_provider.dart';
 import 'package:jplayer/src/providers/image_service_provider.dart';
-import 'package:string_capitalize/string_capitalize.dart';
 
 class CarPlayHandler {
   static const _channel = MethodChannel('com.prodigytech.jellybox/carplay');
+  static const _recentAlbumsLimit = 20;
   static final _items = <String, LibraryItem>{};
   static var _songs = <LibraryItem>[];
   static ProviderSubscription<AsyncValue<List<GeneratedPlaylist>>>? _mixesSub;
@@ -146,9 +147,12 @@ class CarPlayHandler {
     final libraryId = ref.read(currentLibraryProvider).valueOrNull?.id;
     final recent = await _fetch(() async {
       final resp = await client.getAlbums(
-        userId: user.userId,
-        libraryId: libraryId,
-        limit: '20',
+        LibraryQuery(
+          libraryId: libraryId,
+          sort: ItemSort.dateCreated,
+          direction: SortDirection.descending,
+          limit: _recentAlbumsLimit,
+        ),
       );
       return resp.items;
     });
@@ -173,8 +177,8 @@ class CarPlayHandler {
 
     final client = ref.read(mediaServerClientProvider);
     final libraryId = ref.read(currentLibraryProvider).valueOrNull?.id;
-    final sortBy = filter.orderBy.name.capitalize();
-    final sortOrder = filter.desc ? 'Descending' : 'Ascending';
+    final itemSort = filter.orderBy.itemSort;
+    final direction = sortDirectionOf(descending: filter.desc);
     final type = args['type'] as String?;
     if (type == 'mixes') {
       return {'items': _mixes(ref), 'sort': sort, 'hasMore': false};
@@ -188,27 +192,28 @@ class CarPlayHandler {
       if (query.isNotEmpty) {
         final resp = await switch (type) {
           'albums' => client.searchAlbums(
-            userId: user.userId,
-            libraryId: libraryId,
-            searchTerm: query,
-            startIndex: startIndex.toString(),
+            SearchQuery(
+              term: query,
+              libraryId: libraryId,
+              startIndex: startIndex,
+            ),
           ),
           'artists' => client.searchArtists(
-            userId: user.userId,
-            searchTerm: query,
-            startIndex: startIndex.toString(),
+            SearchQuery(term: query, startIndex: startIndex),
           ),
           'playlists' => client.searchPlaylists(
-            userId: user.userId,
-            libraryId: libraryId ?? '',
-            searchTerm: query,
-            startIndex: startIndex.toString(),
+            SearchQuery(
+              term: query,
+              libraryId: libraryId,
+              startIndex: startIndex,
+            ),
           ),
           'songs' => client.searchSongs(
-            userId: user.userId,
-            libraryId: libraryId,
-            searchTerm: query,
-            startIndex: startIndex.toString(),
+            SearchQuery(
+              term: query,
+              libraryId: libraryId,
+              startIndex: startIndex,
+            ),
           ),
           _ => throw ArgumentError('Unknown list type: $type'),
         };
@@ -216,31 +221,35 @@ class CarPlayHandler {
       }
       final resp = await switch (type) {
         'albums' => client.getAlbums(
-          userId: user.userId,
-          libraryId: artistId != null ? '' : libraryId,
-          sortBy: sortBy,
-          sortOrder: sortOrder,
-          startIndex: startIndex.toString(),
-          artistIds: artistId != null ? [artistId] : const [],
+          LibraryQuery(
+            libraryId: artistId != null ? null : libraryId,
+            sort: itemSort,
+            direction: direction,
+            startIndex: startIndex,
+            artistIds: artistId != null ? [artistId] : const [],
+          ),
         ),
         'artists' => client.getArtists(
-          userId: user.userId,
-          sortBy: sortBy,
-          sortOrder: sortOrder,
-          startIndex: startIndex.toString(),
+          LibraryQuery(
+            sort: itemSort,
+            direction: direction,
+            startIndex: startIndex,
+          ),
         ),
         'playlists' => client.getPlaylists(
-          userId: user.userId,
-          sortBy: sortBy,
-          sortOrder: sortOrder,
-          startIndex: startIndex.toString(),
+          LibraryQuery(
+            sort: itemSort,
+            direction: direction,
+            startIndex: startIndex,
+          ),
         ),
         'songs' => client.getAllSongs(
-          userId: user.userId,
-          libraryId: libraryId,
-          sortBy: filter.orderBy == EntityFilter.sortName ? 'Name' : sortBy,
-          sortOrder: sortOrder,
-          startIndex: startIndex.toString(),
+          LibraryQuery(
+            libraryId: libraryId,
+            sort: itemSort,
+            direction: direction,
+            startIndex: startIndex,
+          ),
         ),
         _ => throw ArgumentError('Unknown list type: $type'),
       };
@@ -278,32 +287,23 @@ class CarPlayHandler {
     final results = await Future.wait([
       _fetch(() async {
         final resp = await client.searchAlbums(
-          userId: user.userId,
-          libraryId: libraryId,
-          searchTerm: query,
+          SearchQuery(term: query, libraryId: libraryId),
         );
         return resp.items;
       }),
       _fetch(() async {
-        final resp = await client.searchArtists(
-          userId: user.userId,
-          searchTerm: query,
-        );
+        final resp = await client.searchArtists(SearchQuery(term: query));
         return resp.items;
       }),
       _fetch(() async {
         final resp = await client.searchPlaylists(
-          userId: user.userId,
-          libraryId: libraryId ?? '',
-          searchTerm: query,
+          SearchQuery(term: query, libraryId: libraryId),
         );
         return resp.items;
       }),
       _fetch(() async {
         final resp = await client.searchSongs(
-          userId: user.userId,
-          libraryId: libraryId,
-          searchTerm: query,
+          SearchQuery(term: query, libraryId: libraryId),
         );
         return resp.items;
       }),

--- a/lib/src/data/backend/emby/emby_authenticator.dart
+++ b/lib/src/data/backend/emby/emby_authenticator.dart
@@ -1,0 +1,23 @@
+import 'package:dio/dio.dart';
+import 'package:jplayer/src/data/api/api.dart';
+import 'package:jplayer/src/data/backend/mediabrowser_authenticator.dart';
+import 'package:jplayer/src/data/dto/dto.dart';
+import 'package:jplayer/src/data/params/params.dart';
+
+class EmbyAuthenticator extends MediaBrowserAuthenticator {
+  const EmbyAuthenticator(this._client);
+
+  final Dio _client;
+
+  @override
+  Future<SignInResultDTO> authenticate(
+    UserCredentials credentials, {
+    required String serverUrl,
+  }) async {
+    final response = await EmbyApi(
+      _client,
+      baseUrl: serverUrl,
+    ).signIn(credentials: credentials);
+    return response.data;
+  }
+}

--- a/lib/src/data/backend/emby/emby_client.dart
+++ b/lib/src/data/backend/emby/emby_client.dart
@@ -5,11 +5,15 @@ import 'package:jplayer/src/data/api/api.dart';
 import 'package:jplayer/src/data/backend/emby/mappers/emby_item_mapper.dart';
 import 'package:jplayer/src/data/backend/item_image_ref.dart';
 import 'package:jplayer/src/data/backend/jellyfin/jellyfin_playlist_generator.dart';
+import 'package:jplayer/src/data/backend/library_query.dart';
+import 'package:jplayer/src/data/backend/mappers/lyrics_dto_mapper.dart';
 import 'package:jplayer/src/data/backend/mappers/subtitle_track_mapper.dart';
+import 'package:jplayer/src/data/backend/media_server_capabilities.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
+import 'package:jplayer/src/data/backend/media_server_exception.dart';
+import 'package:jplayer/src/data/backend/mediabrowser_query.dart';
 import 'package:jplayer/src/data/backend/playback_report.dart';
 import 'package:jplayer/src/data/backend/stream_source.dart';
-import 'package:jplayer/src/data/dto/dto.dart';
 import 'package:jplayer/src/data/params/params.dart';
 import 'package:jplayer/src/domain/models/models.dart';
 
@@ -26,6 +30,9 @@ class EmbyClient implements MediaServerClient {
   static const _defaultImageSize = 420;
   static const _sizeParams = {'MaxWidth', 'MaxHeight'};
 
+  @override
+  MediaServerCapabilities get capabilities => const MediaServerCapabilities();
+
   final EmbyApi _api;
   final String _baseUrl;
   final String userId;
@@ -33,163 +40,103 @@ class EmbyClient implements MediaServerClient {
   final String deviceId;
 
   @override
-  Future<LibraryPage> getAlbums({
-    required String userId,
-    String? libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortBy = 'DateCreated,SortName',
-    String? contributingArtistIds,
-    String sortOrder = 'Descending',
-    List<String> artistIds = const [],
-    List<String> genreIds = const [],
-    List<String> filters = const [],
-    List<String> ids = const [],
-  }) async {
+  Future<LibraryPage> getAlbums(LibraryQuery query) async {
     final response = await _api.getAlbums(
       userId: userId,
-      libraryId: libraryId,
-      startIndex: startIndex,
-      limit: limit,
-      sortBy: sortBy,
-      contributingArtistIds: contributingArtistIds,
-      sortOrder: sortOrder,
-      artistIds: artistIds,
-      genreIds: genreIds,
-      filters: filters,
-      ids: ids,
+      libraryId: query.libraryId,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortBy: mediaBrowserSort(query.sort),
+      contributingArtistIds: query.appearsOnArtistId,
+      sortOrder: mediaBrowserSortOrder(query.direction),
+      artistIds: query.artistIds,
+      genreIds: query.genreIds,
+      filters: mediaBrowserFilters(query.filters),
+      ids: query.ids,
     );
     return response.data.toEmbyLibraryPage();
   }
 
   @override
-  Future<LibraryPage> getArtists({
-    required String userId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortBy = 'SortName',
-    String sortOrder = 'Descending',
-    List<String> filters = const [],
-  }) async {
+  Future<LibraryPage> getArtists(LibraryQuery query) async {
     final response = await _api.getArtists(
       userId: userId,
-      startIndex: startIndex,
-      limit: limit,
-      sortBy: sortBy,
-      sortOrder: sortOrder,
-      filters: filters,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortBy: mediaBrowserSort(query.sort, target: ItemKind.artist),
+      sortOrder: mediaBrowserSortOrder(query.direction),
+      filters: mediaBrowserFilters(query.filters),
     );
     return response.data.toEmbyLibraryPage();
   }
 
   @override
-  Future<LibraryPage> getGenres({
-    required String userId,
-    String? libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortBy = 'SortName',
-    String sortOrder = 'Ascending',
-  }) async {
+  Future<LibraryPage> getGenres(LibraryQuery query) async {
     final response = await _api.getGenres(
       userId: userId,
-      libraryId: libraryId,
-      startIndex: startIndex,
-      limit: limit,
-      sortBy: sortBy,
-      sortOrder: sortOrder,
+      libraryId: query.libraryId,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortBy: mediaBrowserSort(query.sort, target: ItemKind.genre),
+      sortOrder: mediaBrowserSortOrder(query.direction),
     );
     return response.data.toEmbyLibraryPage();
   }
 
   @override
-  Future<LibraryPage> getPlaylists({
-    required String userId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortBy = 'DateCreated,SortName',
-    String? contributingArtistIds,
-    String sortOrder = 'Descending',
-    List<String> artistIds = const [],
-  }) async {
+  Future<LibraryPage> getPlaylists(LibraryQuery query) async {
     final response = await _api.getPlaylists(
       userId: userId,
-      startIndex: startIndex,
-      limit: limit,
-      sortBy: sortBy,
-      contributingArtistIds: contributingArtistIds,
-      sortOrder: sortOrder,
-      artistIds: artistIds,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortBy: mediaBrowserSort(query.sort, target: ItemKind.playlist),
+      contributingArtistIds: query.appearsOnArtistId,
+      sortOrder: mediaBrowserSortOrder(query.direction),
+      artistIds: query.artistIds,
     );
     return response.data.toEmbyLibraryPage();
   }
 
   @override
-  Future<LibraryPage> getAllSongs({
-    required String userId,
-    String? libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortBy = 'SortName',
-    String sortOrder = 'Ascending',
-    List<String> filters = const [],
-    List<String> fields = const ['MediaSources'],
-  }) async {
+  Future<LibraryPage> getAllSongs(LibraryQuery query) async {
     final response = await _api.getAllSongs(
       userId: userId,
-      libraryId: libraryId,
-      startIndex: startIndex,
-      limit: limit,
-      sortBy: sortBy,
-      sortOrder: sortOrder,
-      filters: filters,
-      fields: fields,
+      libraryId: query.libraryId,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortBy: mediaBrowserSort(query.sort, target: ItemKind.song),
+      sortOrder: mediaBrowserSortOrder(query.direction),
+      filters: mediaBrowserFilters(query.filters),
+      fields: mediaBrowserFields(query.fields),
     );
     return response.data.toEmbyLibraryPage();
   }
 
   @override
-  Future<LibraryPage> getSongs({
-    required String userId,
-    required String albumId,
-  }) async {
+  Future<LibraryPage> getSongs(String albumId) async {
     final response = await _api.getSongs(userId: userId, albumId: albumId);
     return response.data.toEmbyLibraryPage();
   }
 
   @override
-  Future<LibraryPage> getSongsOfSet({
-    required String userId,
-    String? libraryId,
-    List<String> artistIds = const [],
-    List<String> genreIds = const [],
-    List<String> filters = const [],
-    String sortBy = 'AlbumArtist,Album,ParentIndexNumber,IndexNumber',
-    String sortOrder = 'Ascending',
-    String startIndex = '0',
-    String limit = '300',
-    List<String> fields = const ['MediaSources'],
-  }) async {
+  Future<LibraryPage> getSongsOfSet(LibraryQuery query) async {
     final response = await _api.getSongsOfSet(
       userId: userId,
-      libraryId: libraryId,
-      artistIds: artistIds,
-      genreIds: genreIds,
-      filters: filters,
-      sortBy: sortBy,
-      sortOrder: sortOrder,
-      startIndex: startIndex,
-      limit: limit,
-      fields: fields,
+      libraryId: query.libraryId,
+      artistIds: query.artistIds,
+      genreIds: query.genreIds,
+      filters: mediaBrowserFilters(query.filters),
+      sortBy: mediaBrowserSort(query.sort, target: ItemKind.song),
+      sortOrder: mediaBrowserSortOrder(query.direction),
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      fields: mediaBrowserFields(query.fields),
     );
     return response.data.toEmbyLibraryPage();
   }
 
   @override
-  Future<LibraryPage> getPlaylistSongs({
-    required String userId,
-    required String playlistId,
-  }) async {
+  Future<LibraryPage> getPlaylistSongs(String playlistId) async {
     final response = await _api.getPlaylistSongs(
       playlistId: playlistId,
       userId: userId,
@@ -198,129 +145,94 @@ class EmbyClient implements MediaServerClient {
   }
 
   @override
-  Future<LibraryPage> getSimilarAlbums({
-    required String userId,
-    required String albumId,
-    String limit = '12',
-  }) async {
+  Future<LibraryPage> getSimilarAlbums(String albumId, {int limit = 12}) async {
     final response = await _api.getSimilarAlbums(
       albumId: albumId,
       userId: userId,
-      limit: limit,
+      limit: '$limit',
     );
     return response.data.toEmbyLibraryPage();
   }
 
   @override
   Future<List<GeneratedPlaylist>> generateTodaysPlaylists({
-    required String userId,
     String? libraryId,
     bool includeDiscovery = false,
   }) => generateJellyfinTodaysPlaylists(
     this,
-    userId: userId,
     libraryId: libraryId,
     includeDiscovery: includeDiscovery,
   );
 
   @override
   Future<List<LibraryItem>> getGeneratedPlaylistSongs({
-    required String userId,
     required String playlistId,
     String? libraryId,
   }) => fetchJellyfinGeneratedPlaylistSongs(
     this,
-    userId: userId,
     playlistId: playlistId,
     libraryId: libraryId,
   );
 
   @override
-  Future<LibraryPage> getLibraries({required String userId}) async {
+  Future<LibraryPage> getLibraries() async {
     final response = await _api.getLibraries(userId: userId);
     return response.data.toEmbyLibraryPage();
   }
 
   @override
-  Future<LibraryItem> getItem(String itemId) async {
+  Future<LibraryItem> getItem(String itemId, {required ItemKind kind}) async {
     final response = await _api.getItem(userId: userId, itemId: itemId);
     return response.data.toEmbyLibraryItem();
   }
 
   @override
-  Future<LibraryPage> searchAlbums({
-    required String userId,
-    required String searchTerm,
-    String? libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortOrder = 'Descending',
-  }) async {
+  Future<LibraryPage> searchAlbums(SearchQuery query) async {
     final response = await _api.searchAlbums(
       userId: userId,
-      searchTerm: searchTerm,
-      libraryId: libraryId,
-      startIndex: startIndex,
-      limit: limit,
-      sortOrder: sortOrder,
+      searchTerm: query.term,
+      libraryId: query.libraryId,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortOrder: mediaBrowserSortOrder(query.direction),
     );
     return response.data.toEmbyLibraryPage();
   }
 
   @override
-  Future<LibraryPage> searchArtists({
-    required String userId,
-    required String searchTerm,
-    String startIndex = '0',
-    String limit = '100',
-    String sortOrder = 'Descending',
-  }) async {
+  Future<LibraryPage> searchArtists(SearchQuery query) async {
     final response = await _api.searchArtists(
       userId: userId,
-      searchTerm: searchTerm,
-      startIndex: startIndex,
-      limit: limit,
-      sortOrder: sortOrder,
+      searchTerm: query.term,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortOrder: mediaBrowserSortOrder(query.direction),
     );
     return response.data.toEmbyLibraryPage();
   }
 
   @override
-  Future<LibraryPage> searchSongs({
-    required String userId,
-    required String searchTerm,
-    String? libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortOrder = 'Descending',
-  }) async {
+  Future<LibraryPage> searchSongs(SearchQuery query) async {
     final response = await _api.searchSongs(
       userId: userId,
-      searchTerm: searchTerm,
-      libraryId: libraryId,
-      startIndex: startIndex,
-      limit: limit,
-      sortOrder: sortOrder,
+      searchTerm: query.term,
+      libraryId: query.libraryId,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortOrder: mediaBrowserSortOrder(query.direction),
     );
     return response.data.toEmbyLibraryPage();
   }
 
   @override
-  Future<LibraryPage> searchPlaylists({
-    required String userId,
-    required String searchTerm,
-    required String libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortOrder = 'Descending',
-  }) async {
+  Future<LibraryPage> searchPlaylists(SearchQuery query) async {
     final response = await _api.searchPlaylists(
       userId: userId,
-      libraryId: libraryId,
-      searchTerm: searchTerm,
-      startIndex: startIndex,
-      limit: limit,
-      sortOrder: sortOrder,
+      libraryId: query.libraryId ?? '',
+      searchTerm: query.term,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortOrder: mediaBrowserSortOrder(query.direction),
     );
     return response.data.toEmbyLibraryPage();
   }
@@ -365,7 +277,7 @@ class EmbyClient implements MediaServerClient {
   }
 
   @override
-  Future<LyricsDTO> getLyrics(String itemId) async {
+  Future<Lyrics?> getLyrics(String itemId) async {
     final item = await _api.getItem(userId: userId, itemId: itemId);
     for (final source in item.data.mediaSources) {
       final sourceId = source.id;
@@ -376,9 +288,9 @@ class EmbyClient implements MediaServerClient {
         mediaSourceId: sourceId,
         index: index,
       );
-      return parseSubtitleTrack(track.data).toLyricsDTO();
+      return parseSubtitleTrack(track.data).toLyricsDTO().toLyrics();
     }
-    return const LyricsDTO();
+    return null;
   }
 
   @override
@@ -501,8 +413,9 @@ class EmbyClient implements MediaServerClient {
       await _api.getArtists(userId: userId, limit: '1');
       return SessionStatus.valid;
     } on DioException catch (e) {
-      final statusCode = e.response?.statusCode;
-      if (statusCode == 401 || statusCode == 403) return SessionStatus.invalid;
+      if (MediaServerException.fromDio(e).isUnauthorized) {
+        return SessionStatus.invalid;
+      }
       return SessionStatus.unreachable;
     } on Object {
       return SessionStatus.unreachable;

--- a/lib/src/data/backend/jellyfin/jellyfin_authenticator.dart
+++ b/lib/src/data/backend/jellyfin/jellyfin_authenticator.dart
@@ -1,0 +1,23 @@
+import 'package:dio/dio.dart';
+import 'package:jplayer/src/data/api/api.dart';
+import 'package:jplayer/src/data/backend/mediabrowser_authenticator.dart';
+import 'package:jplayer/src/data/dto/dto.dart';
+import 'package:jplayer/src/data/params/params.dart';
+
+class JellyfinAuthenticator extends MediaBrowserAuthenticator {
+  const JellyfinAuthenticator(this._client);
+
+  final Dio _client;
+
+  @override
+  Future<SignInResultDTO> authenticate(
+    UserCredentials credentials, {
+    required String serverUrl,
+  }) async {
+    final response = await JellyfinApi(
+      _client,
+      baseUrl: serverUrl,
+    ).signIn(credentials: credentials);
+    return response.data;
+  }
+}

--- a/lib/src/data/backend/jellyfin/jellyfin_client.dart
+++ b/lib/src/data/backend/jellyfin/jellyfin_client.dart
@@ -4,11 +4,15 @@ import 'package:jplayer/src/core/audio/stream_target_profile.dart';
 import 'package:jplayer/src/data/api/api.dart';
 import 'package:jplayer/src/data/backend/item_image_ref.dart';
 import 'package:jplayer/src/data/backend/jellyfin/jellyfin_playlist_generator.dart';
+import 'package:jplayer/src/data/backend/library_query.dart';
 import 'package:jplayer/src/data/backend/mappers/item_dto_mapper.dart';
+import 'package:jplayer/src/data/backend/mappers/lyrics_dto_mapper.dart';
+import 'package:jplayer/src/data/backend/media_server_capabilities.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
+import 'package:jplayer/src/data/backend/media_server_exception.dart';
+import 'package:jplayer/src/data/backend/mediabrowser_query.dart';
 import 'package:jplayer/src/data/backend/playback_report.dart';
 import 'package:jplayer/src/data/backend/stream_source.dart';
-import 'package:jplayer/src/data/dto/dto.dart';
 import 'package:jplayer/src/data/params/params.dart';
 import 'package:jplayer/src/domain/models/models.dart';
 
@@ -25,6 +29,9 @@ class JellyfinClient implements MediaServerClient {
   static const _defaultImageSize = 420;
   static const _sizeParams = {'fillHeight', 'fillWidth'};
 
+  @override
+  MediaServerCapabilities get capabilities => const MediaServerCapabilities();
+
   final JellyfinApi _api;
   final String _baseUrl;
   final String userId;
@@ -32,163 +39,103 @@ class JellyfinClient implements MediaServerClient {
   final String deviceId;
 
   @override
-  Future<LibraryPage> getAlbums({
-    required String userId,
-    String? libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortBy = 'DateCreated,SortName',
-    String? contributingArtistIds,
-    String sortOrder = 'Descending',
-    List<String> artistIds = const [],
-    List<String> genreIds = const [],
-    List<String> filters = const [],
-    List<String> ids = const [],
-  }) async {
+  Future<LibraryPage> getAlbums(LibraryQuery query) async {
     final response = await _api.getAlbums(
       userId: userId,
-      libraryId: libraryId,
-      startIndex: startIndex,
-      limit: limit,
-      sortBy: sortBy,
-      contributingArtistIds: contributingArtistIds,
-      sortOrder: sortOrder,
-      artistIds: artistIds,
-      genreIds: genreIds,
-      filters: filters,
-      ids: ids,
+      libraryId: query.libraryId,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortBy: mediaBrowserSort(query.sort),
+      contributingArtistIds: query.appearsOnArtistId,
+      sortOrder: mediaBrowserSortOrder(query.direction),
+      artistIds: query.artistIds,
+      genreIds: query.genreIds,
+      filters: mediaBrowserFilters(query.filters),
+      ids: query.ids,
     );
     return response.data.toLibraryPage();
   }
 
   @override
-  Future<LibraryPage> getArtists({
-    required String userId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortBy = 'SortName',
-    String sortOrder = 'Descending',
-    List<String> filters = const [],
-  }) async {
+  Future<LibraryPage> getArtists(LibraryQuery query) async {
     final response = await _api.getArtists(
       userId: userId,
-      startIndex: startIndex,
-      limit: limit,
-      sortBy: sortBy,
-      sortOrder: sortOrder,
-      filters: filters,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortBy: mediaBrowserSort(query.sort, target: ItemKind.artist),
+      sortOrder: mediaBrowserSortOrder(query.direction),
+      filters: mediaBrowserFilters(query.filters),
     );
     return response.data.toLibraryPage();
   }
 
   @override
-  Future<LibraryPage> getGenres({
-    required String userId,
-    String? libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortBy = 'SortName',
-    String sortOrder = 'Ascending',
-  }) async {
+  Future<LibraryPage> getGenres(LibraryQuery query) async {
     final response = await _api.getGenres(
       userId: userId,
-      libraryId: libraryId,
-      startIndex: startIndex,
-      limit: limit,
-      sortBy: sortBy,
-      sortOrder: sortOrder,
+      libraryId: query.libraryId,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortBy: mediaBrowserSort(query.sort, target: ItemKind.genre),
+      sortOrder: mediaBrowserSortOrder(query.direction),
     );
     return response.data.toLibraryPage();
   }
 
   @override
-  Future<LibraryPage> getPlaylists({
-    required String userId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortBy = 'DateCreated,SortName',
-    String? contributingArtistIds,
-    String sortOrder = 'Descending',
-    List<String> artistIds = const [],
-  }) async {
+  Future<LibraryPage> getPlaylists(LibraryQuery query) async {
     final response = await _api.getPlaylists(
       userId: userId,
-      startIndex: startIndex,
-      limit: limit,
-      sortBy: sortBy,
-      contributingArtistIds: contributingArtistIds,
-      sortOrder: sortOrder,
-      artistIds: artistIds,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortBy: mediaBrowserSort(query.sort, target: ItemKind.playlist),
+      contributingArtistIds: query.appearsOnArtistId,
+      sortOrder: mediaBrowserSortOrder(query.direction),
+      artistIds: query.artistIds,
     );
     return response.data.toLibraryPage();
   }
 
   @override
-  Future<LibraryPage> getAllSongs({
-    required String userId,
-    String? libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortBy = 'SortName',
-    String sortOrder = 'Ascending',
-    List<String> filters = const [],
-    List<String> fields = const ['MediaSources'],
-  }) async {
+  Future<LibraryPage> getAllSongs(LibraryQuery query) async {
     final response = await _api.getAllSongs(
       userId: userId,
-      libraryId: libraryId,
-      startIndex: startIndex,
-      limit: limit,
-      sortBy: sortBy,
-      sortOrder: sortOrder,
-      filters: filters,
-      fields: fields,
+      libraryId: query.libraryId,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortBy: mediaBrowserSort(query.sort, target: ItemKind.song),
+      sortOrder: mediaBrowserSortOrder(query.direction),
+      filters: mediaBrowserFilters(query.filters),
+      fields: mediaBrowserFields(query.fields),
     );
     return response.data.toLibraryPage();
   }
 
   @override
-  Future<LibraryPage> getSongs({
-    required String userId,
-    required String albumId,
-  }) async {
+  Future<LibraryPage> getSongs(String albumId) async {
     final response = await _api.getSongs(userId: userId, albumId: albumId);
     return response.data.toLibraryPage();
   }
 
   @override
-  Future<LibraryPage> getSongsOfSet({
-    required String userId,
-    String? libraryId,
-    List<String> artistIds = const [],
-    List<String> genreIds = const [],
-    List<String> filters = const [],
-    String sortBy = 'AlbumArtist,Album,ParentIndexNumber,IndexNumber',
-    String sortOrder = 'Ascending',
-    String startIndex = '0',
-    String limit = '300',
-    List<String> fields = const ['MediaSources'],
-  }) async {
+  Future<LibraryPage> getSongsOfSet(LibraryQuery query) async {
     final response = await _api.getSongsOfSet(
       userId: userId,
-      libraryId: libraryId,
-      artistIds: artistIds,
-      genreIds: genreIds,
-      filters: filters,
-      sortBy: sortBy,
-      sortOrder: sortOrder,
-      startIndex: startIndex,
-      limit: limit,
-      fields: fields,
+      libraryId: query.libraryId,
+      artistIds: query.artistIds,
+      genreIds: query.genreIds,
+      filters: mediaBrowserFilters(query.filters),
+      sortBy: mediaBrowserSort(query.sort, target: ItemKind.song),
+      sortOrder: mediaBrowserSortOrder(query.direction),
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      fields: mediaBrowserFields(query.fields),
     );
     return response.data.toLibraryPage();
   }
 
   @override
-  Future<LibraryPage> getPlaylistSongs({
-    required String userId,
-    required String playlistId,
-  }) async {
+  Future<LibraryPage> getPlaylistSongs(String playlistId) async {
     final response = await _api.getPlaylistSongs(
       playlistId: playlistId,
       userId: userId,
@@ -197,129 +144,94 @@ class JellyfinClient implements MediaServerClient {
   }
 
   @override
-  Future<LibraryPage> getSimilarAlbums({
-    required String userId,
-    required String albumId,
-    String limit = '12',
-  }) async {
+  Future<LibraryPage> getSimilarAlbums(String albumId, {int limit = 12}) async {
     final response = await _api.getSimilarAlbums(
       albumId: albumId,
       userId: userId,
-      limit: limit,
+      limit: '$limit',
     );
     return response.data.toLibraryPage();
   }
 
   @override
   Future<List<GeneratedPlaylist>> generateTodaysPlaylists({
-    required String userId,
     String? libraryId,
     bool includeDiscovery = false,
   }) => generateJellyfinTodaysPlaylists(
     this,
-    userId: userId,
     libraryId: libraryId,
     includeDiscovery: includeDiscovery,
   );
 
   @override
   Future<List<LibraryItem>> getGeneratedPlaylistSongs({
-    required String userId,
     required String playlistId,
     String? libraryId,
   }) => fetchJellyfinGeneratedPlaylistSongs(
     this,
-    userId: userId,
     playlistId: playlistId,
     libraryId: libraryId,
   );
 
   @override
-  Future<LibraryPage> getLibraries({required String userId}) async {
+  Future<LibraryPage> getLibraries() async {
     final response = await _api.getLibraries(userId: userId);
     return response.data.toLibraryPage();
   }
 
   @override
-  Future<LibraryItem> getItem(String itemId) async {
+  Future<LibraryItem> getItem(String itemId, {required ItemKind kind}) async {
     final response = await _api.getItem(itemId: itemId);
     return response.data.toLibraryItem();
   }
 
   @override
-  Future<LibraryPage> searchAlbums({
-    required String userId,
-    required String searchTerm,
-    String? libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortOrder = 'Descending',
-  }) async {
+  Future<LibraryPage> searchAlbums(SearchQuery query) async {
     final response = await _api.searchAlbums(
       userId: userId,
-      searchTerm: searchTerm,
-      libraryId: libraryId,
-      startIndex: startIndex,
-      limit: limit,
-      sortOrder: sortOrder,
+      searchTerm: query.term,
+      libraryId: query.libraryId,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortOrder: mediaBrowserSortOrder(query.direction),
     );
     return response.data.toLibraryPage();
   }
 
   @override
-  Future<LibraryPage> searchArtists({
-    required String userId,
-    required String searchTerm,
-    String startIndex = '0',
-    String limit = '100',
-    String sortOrder = 'Descending',
-  }) async {
+  Future<LibraryPage> searchArtists(SearchQuery query) async {
     final response = await _api.searchArtists(
       userId: userId,
-      searchTerm: searchTerm,
-      startIndex: startIndex,
-      limit: limit,
-      sortOrder: sortOrder,
+      searchTerm: query.term,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortOrder: mediaBrowserSortOrder(query.direction),
     );
     return response.data.toLibraryPage();
   }
 
   @override
-  Future<LibraryPage> searchSongs({
-    required String userId,
-    required String searchTerm,
-    String? libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortOrder = 'Descending',
-  }) async {
+  Future<LibraryPage> searchSongs(SearchQuery query) async {
     final response = await _api.searchSongs(
       userId: userId,
-      searchTerm: searchTerm,
-      libraryId: libraryId,
-      startIndex: startIndex,
-      limit: limit,
-      sortOrder: sortOrder,
+      searchTerm: query.term,
+      libraryId: query.libraryId,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortOrder: mediaBrowserSortOrder(query.direction),
     );
     return response.data.toLibraryPage();
   }
 
   @override
-  Future<LibraryPage> searchPlaylists({
-    required String userId,
-    required String searchTerm,
-    required String libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortOrder = 'Descending',
-  }) async {
+  Future<LibraryPage> searchPlaylists(SearchQuery query) async {
     final response = await _api.searchPlaylists(
       userId: userId,
-      libraryId: libraryId,
-      searchTerm: searchTerm,
-      startIndex: startIndex,
-      limit: limit,
-      sortOrder: sortOrder,
+      libraryId: query.libraryId ?? '',
+      searchTerm: query.term,
+      startIndex: '${query.startIndex}',
+      limit: '${query.limit}',
+      sortOrder: mediaBrowserSortOrder(query.direction),
     );
     return response.data.toLibraryPage();
   }
@@ -364,9 +276,14 @@ class JellyfinClient implements MediaServerClient {
   }
 
   @override
-  Future<LyricsDTO> getLyrics(String itemId) async {
-    final response = await _api.getLyrics(itemId: itemId);
-    return response.data;
+  Future<Lyrics?> getLyrics(String itemId) async {
+    try {
+      final response = await _api.getLyrics(itemId: itemId);
+      return response.data.toLyrics();
+    } on DioException catch (e) {
+      if (MediaServerException.fromDio(e).isNotFound) return null;
+      rethrow;
+    }
   }
 
   @override
@@ -489,8 +406,9 @@ class JellyfinClient implements MediaServerClient {
       await _api.getArtists(userId: userId, limit: '1');
       return SessionStatus.valid;
     } on DioException catch (e) {
-      final statusCode = e.response?.statusCode;
-      if (statusCode == 401 || statusCode == 403) return SessionStatus.invalid;
+      if (MediaServerException.fromDio(e).isUnauthorized) {
+        return SessionStatus.invalid;
+      }
       return SessionStatus.unreachable;
     } on Object {
       return SessionStatus.unreachable;

--- a/lib/src/data/backend/jellyfin/jellyfin_playlist_generator.dart
+++ b/lib/src/data/backend/jellyfin/jellyfin_playlist_generator.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:jplayer/src/data/backend/library_query.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
 import 'package:jplayer/src/data/backend/playlist_generation.dart';
 import 'package:jplayer/src/domain/models/models.dart';
@@ -8,6 +9,7 @@ const jellyfinGenreMixIdPrefix = 'jellybox:genre-mix:';
 const jellyfinGenreDiscoveryIdPrefix = 'jellybox:genre-discovery:';
 
 const _playedSongsScanLimit = 200;
+const _genreScanLimit = 500;
 const _genreCandidateCount = 5;
 const _discoveryCandidateCount = 8;
 const _maxMixPlaylists = 3;
@@ -35,7 +37,6 @@ List<String> jellyfinGenreIdsOf(String playlistId) {
 
 Future<List<GeneratedPlaylist>> generateJellyfinTodaysPlaylists(
   MediaServerClient client, {
-  required String userId,
   String? libraryId,
   bool includeDiscovery = false,
   Random? random,
@@ -43,22 +44,21 @@ Future<List<GeneratedPlaylist>> generateJellyfinTodaysPlaylists(
   final rng = random ?? Random();
 
   final played = await client.getAllSongs(
-    userId: userId,
-    libraryId: libraryId,
-    sortBy: 'PlayCount',
-    sortOrder: 'Descending',
-    filters: const ['IsPlayed'],
-    limit: '$_playedSongsScanLimit',
-    fields: const ['Genres'],
+    LibraryQuery(
+      libraryId: libraryId,
+      sort: ItemSort.playCount,
+      direction: SortDirection.descending,
+      filters: const {ItemFilterFlag.played},
+      fields: const {ItemField.genres},
+      limit: _playedSongsScanLimit,
+    ),
   );
 
   final ranking = _rankPlayedGenres(played.items);
   if (ranking.ranked.isEmpty && !includeDiscovery) return const [];
 
   final allGenres = await client.getGenres(
-    userId: userId,
-    libraryId: libraryId,
-    limit: '500',
+    LibraryQuery(libraryId: libraryId, limit: _genreScanLimit),
   );
 
   final idsByKey = <String, List<String>>{};
@@ -72,7 +72,6 @@ Future<List<GeneratedPlaylist>> generateJellyfinTodaysPlaylists(
 
   final playlists = await _mixPlaylists(
     client,
-    userId: userId,
     libraryId: libraryId,
     ranking: ranking,
     idsByKey: idsByKey,
@@ -84,7 +83,6 @@ Future<List<GeneratedPlaylist>> generateJellyfinTodaysPlaylists(
     ...playlists,
     ...await _discoveryPlaylists(
       client,
-      userId: userId,
       libraryId: libraryId,
       idsByKey: idsByKey,
       nameByKey: nameByKey,
@@ -129,7 +127,6 @@ _GenreRanking _rankPlayedGenres(List<LibraryItem> played) {
 
 Future<List<GeneratedPlaylist>> _mixPlaylists(
   MediaServerClient client, {
-  required String userId,
   required String? libraryId,
   required _GenreRanking ranking,
   required Map<String, List<String>> idsByKey,
@@ -148,12 +145,13 @@ Future<List<GeneratedPlaylist>> _mixPlaylists(
   final probes = await Future.wait([
     for (final candidate in candidates)
       client.getSongsOfSet(
-        userId: userId,
-        libraryId: libraryId,
-        genreIds: candidate.ids,
-        sortBy: 'Random',
-        limit: '$genreProbeLimit',
-        fields: const [],
+        LibraryQuery(
+          libraryId: libraryId,
+          genreIds: candidate.ids,
+          sort: ItemSort.random,
+          fields: const {},
+          limit: genreProbeLimit,
+        ),
       ),
   ]);
 
@@ -181,7 +179,6 @@ Future<List<GeneratedPlaylist>> _mixPlaylists(
 
 Future<List<GeneratedPlaylist>> _discoveryPlaylists(
   MediaServerClient client, {
-  required String userId,
   required String? libraryId,
   required Map<String, List<String>> idsByKey,
   required Map<String, String> nameByKey,
@@ -196,13 +193,14 @@ Future<List<GeneratedPlaylist>> _discoveryPlaylists(
   final probes = await Future.wait([
     for (final key in candidates)
       client.getSongsOfSet(
-        userId: userId,
-        libraryId: libraryId,
-        genreIds: idsByKey[key]!,
-        filters: const ['IsUnplayed'],
-        sortBy: 'Random',
-        limit: '$genreProbeLimit',
-        fields: const [],
+        LibraryQuery(
+          libraryId: libraryId,
+          genreIds: idsByKey[key]!,
+          filters: const {ItemFilterFlag.unplayed},
+          sort: ItemSort.random,
+          fields: const {},
+          limit: genreProbeLimit,
+        ),
       ),
   ]);
 
@@ -230,7 +228,6 @@ Future<List<GeneratedPlaylist>> _discoveryPlaylists(
 
 Future<List<LibraryItem>> fetchJellyfinGeneratedPlaylistSongs(
   MediaServerClient client, {
-  required String userId,
   required String playlistId,
   String? libraryId,
   Random? random,
@@ -242,12 +239,13 @@ Future<List<LibraryItem>> fetchJellyfinGeneratedPlaylistSongs(
 
   if (isJellyfinDiscoveryPlaylistId(playlistId)) {
     final unplayed = await client.getSongsOfSet(
-      userId: userId,
-      libraryId: libraryId,
-      genreIds: genreIds,
-      filters: const ['IsUnplayed'],
-      sortBy: 'Random',
-      limit: '$generatedPlaylistFetchLimit',
+      LibraryQuery(
+        libraryId: libraryId,
+        genreIds: genreIds,
+        filters: const {ItemFilterFlag.unplayed},
+        sort: ItemSort.random,
+        limit: generatedPlaylistFetchLimit,
+      ),
     );
 
     return blendSongs(
@@ -259,21 +257,23 @@ Future<List<LibraryItem>> fetchJellyfinGeneratedPlaylistSongs(
 
   final batches = await Future.wait([
     client.getSongsOfSet(
-      userId: userId,
-      libraryId: libraryId,
-      genreIds: genreIds,
-      filters: const ['IsPlayed'],
-      sortBy: 'PlayCount',
-      sortOrder: 'Descending',
-      limit: '$generatedPlaylistFetchLimit',
+      LibraryQuery(
+        libraryId: libraryId,
+        genreIds: genreIds,
+        filters: const {ItemFilterFlag.played},
+        sort: ItemSort.playCount,
+        direction: SortDirection.descending,
+        limit: generatedPlaylistFetchLimit,
+      ),
     ),
     client.getSongsOfSet(
-      userId: userId,
-      libraryId: libraryId,
-      genreIds: genreIds,
-      filters: const ['IsUnplayed'],
-      sortBy: 'Random',
-      limit: '$generatedPlaylistFetchLimit',
+      LibraryQuery(
+        libraryId: libraryId,
+        genreIds: genreIds,
+        filters: const {ItemFilterFlag.unplayed},
+        sort: ItemSort.random,
+        limit: generatedPlaylistFetchLimit,
+      ),
     ),
   ]);
 

--- a/lib/src/data/backend/library_query.dart
+++ b/lib/src/data/backend/library_query.dart
@@ -1,0 +1,112 @@
+import 'package:jplayer/src/core/enums/enums.dart';
+
+enum ItemSort {
+  name,
+  albumArtist,
+  dateCreated,
+  datePlayed,
+  playCount,
+  dateLastContentAdded,
+  albumOrder,
+  random,
+}
+
+enum SortDirection { ascending, descending }
+
+enum ItemFilterFlag { favorite, played, unplayed }
+
+enum ItemField { audioSources, genres }
+
+class LibraryQuery {
+  const LibraryQuery({
+    this.libraryId,
+    this.sort = ItemSort.name,
+    this.direction = SortDirection.ascending,
+    this.filters = const {},
+    this.fields = const {ItemField.audioSources},
+    this.startIndex = 0,
+    this.limit = 100,
+    this.artistIds = const [],
+    this.genreIds = const [],
+    this.ids = const [],
+    this.appearsOnArtistId,
+  });
+
+  final String? libraryId;
+  final ItemSort sort;
+  final SortDirection direction;
+  final Set<ItemFilterFlag> filters;
+  final Set<ItemField> fields;
+  final int startIndex;
+  final int limit;
+  final List<String> artistIds;
+  final List<String> genreIds;
+  final List<String> ids;
+  final String? appearsOnArtistId;
+
+  LibraryQuery copyWith({
+    String? libraryId,
+    ItemSort? sort,
+    SortDirection? direction,
+    Set<ItemFilterFlag>? filters,
+    Set<ItemField>? fields,
+    int? startIndex,
+    int? limit,
+    List<String>? artistIds,
+    List<String>? genreIds,
+    List<String>? ids,
+    String? appearsOnArtistId,
+  }) => LibraryQuery(
+    libraryId: libraryId ?? this.libraryId,
+    sort: sort ?? this.sort,
+    direction: direction ?? this.direction,
+    filters: filters ?? this.filters,
+    fields: fields ?? this.fields,
+    startIndex: startIndex ?? this.startIndex,
+    limit: limit ?? this.limit,
+    artistIds: artistIds ?? this.artistIds,
+    genreIds: genreIds ?? this.genreIds,
+    ids: ids ?? this.ids,
+    appearsOnArtistId: appearsOnArtistId ?? this.appearsOnArtistId,
+  );
+
+  @override
+  String toString() =>
+      'LibraryQuery(libraryId: $libraryId, sort: $sort, '
+      'direction: $direction, filters: $filters, fields: $fields, '
+      'startIndex: $startIndex, limit: $limit, artistIds: $artistIds, '
+      'genreIds: $genreIds, ids: $ids, appearsOnArtistId: $appearsOnArtistId)';
+}
+
+SortDirection sortDirectionOf({required bool descending}) =>
+    descending ? SortDirection.descending : SortDirection.ascending;
+
+extension EntityFilterSort on EntityFilter {
+  ItemSort get itemSort => switch (this) {
+    EntityFilter.sortName => ItemSort.name,
+    EntityFilter.albumArtist => ItemSort.albumArtist,
+    EntityFilter.dateCreated => ItemSort.dateCreated,
+    EntityFilter.random => ItemSort.random,
+  };
+}
+
+class SearchQuery {
+  const SearchQuery({
+    required this.term,
+    this.libraryId,
+    this.startIndex = 0,
+    this.limit = 100,
+    this.direction = SortDirection.descending,
+  });
+
+  final String term;
+  final String? libraryId;
+  final int startIndex;
+  final int limit;
+  final SortDirection direction;
+
+  @override
+  String toString() =>
+      'SearchQuery(term: $term, libraryId: $libraryId, '
+      'startIndex: $startIndex, limit: $limit, direction: $direction)';
+}

--- a/lib/src/data/backend/mappers/lyrics_dto_mapper.dart
+++ b/lib/src/data/backend/mappers/lyrics_dto_mapper.dart
@@ -1,0 +1,25 @@
+import 'package:jplayer/src/data/dto/dto.dart';
+import 'package:jplayer/src/domain/models/models.dart';
+
+extension LyricsDTOMapping on LyricsDTO {
+  Lyrics toLyrics() => Lyrics(
+    lines: [
+      for (final line in lyrics)
+        LyricLine(
+          text: line.text,
+          start: line.startTime,
+          cues: [
+            for (final cue in line.cues ?? const <LyricLineCueDTO>[])
+              LyricCue(
+                start: cue.startTime,
+                end: cue.endTime,
+                position: cue.position,
+                endPosition: cue.endPosition,
+              ),
+          ],
+        ),
+    ],
+    isSynced: isSynced,
+    offset: offset,
+  );
+}

--- a/lib/src/data/backend/media_server_backends.dart
+++ b/lib/src/data/backend/media_server_backends.dart
@@ -1,0 +1,67 @@
+import 'package:dio/dio.dart';
+import 'package:jplayer/src/data/backend/emby/emby_auth_headers.dart';
+import 'package:jplayer/src/data/backend/emby/emby_authenticator.dart';
+import 'package:jplayer/src/data/backend/emby/emby_client.dart';
+import 'package:jplayer/src/data/backend/jellyfin/jellyfin_auth_headers.dart';
+import 'package:jplayer/src/data/backend/jellyfin/jellyfin_authenticator.dart';
+import 'package:jplayer/src/data/backend/jellyfin/jellyfin_client.dart';
+import 'package:jplayer/src/data/backend/media_server_client.dart';
+import 'package:jplayer/src/data/backend/mediabrowser_probe.dart';
+import 'package:jplayer/src/data/backend/server_auth_headers.dart';
+import 'package:jplayer/src/data/backend/server_probe.dart';
+import 'package:jplayer/src/data/backend/server_session.dart';
+import 'package:jplayer/src/data/backend/server_type.dart';
+
+List<ServerProbe> defaultServerProbes(Dio client) => [
+  MediaBrowserProbe(client),
+];
+
+MediaServerAuthenticator authenticatorFor(
+  ServerType serverType, {
+  required Dio dio,
+}) => switch (serverType) {
+  ServerType.jellyfin => JellyfinAuthenticator(dio),
+  ServerType.emby => EmbyAuthenticator(dio),
+};
+
+ServerAuthHeaders authHeadersFor(
+  ServerType serverType, {
+  required String deviceId,
+  required String deviceName,
+  required String version,
+}) => switch (serverType) {
+  ServerType.jellyfin => JellyfinAuthHeaders(
+    deviceId: deviceId,
+    deviceName: deviceName,
+    version: version,
+  ),
+  ServerType.emby => EmbyAuthHeaders(
+    deviceId: deviceId,
+    deviceName: deviceName,
+    version: version,
+  ),
+};
+
+MediaServerClient clientFor(
+  ServerType serverType, {
+  required Dio dio,
+  required String baseUrl,
+  required String userId,
+  required String token,
+  required String deviceId,
+}) => switch (serverType) {
+  ServerType.jellyfin => JellyfinClient(
+    dio: dio,
+    baseUrl: baseUrl,
+    userId: userId,
+    token: token,
+    deviceId: deviceId,
+  ),
+  ServerType.emby => EmbyClient(
+    dio: dio,
+    baseUrl: baseUrl,
+    userId: userId,
+    token: token,
+    deviceId: deviceId,
+  ),
+};

--- a/lib/src/data/backend/media_server_capabilities.dart
+++ b/lib/src/data/backend/media_server_capabilities.dart
@@ -1,0 +1,11 @@
+class MediaServerCapabilities {
+  const MediaServerCapabilities({
+    this.lyrics = true,
+    this.similarAlbums = true,
+    this.playlistSearch = true,
+  });
+
+  final bool lyrics;
+  final bool similarAlbums;
+  final bool playlistSearch;
+}

--- a/lib/src/data/backend/media_server_client.dart
+++ b/lib/src/data/backend/media_server_client.dart
@@ -1,145 +1,55 @@
 import 'package:jplayer/src/core/audio/stream_target_profile.dart';
+import 'package:jplayer/src/data/backend/library_query.dart';
+import 'package:jplayer/src/data/backend/media_server_capabilities.dart';
 import 'package:jplayer/src/data/backend/playback_report.dart';
 import 'package:jplayer/src/data/backend/stream_source.dart';
-import 'package:jplayer/src/data/dto/dto.dart';
 import 'package:jplayer/src/data/params/params.dart';
 import 'package:jplayer/src/domain/models/models.dart';
 
 enum SessionStatus { valid, invalid, unreachable }
 
 abstract class MediaServerClient {
-  Future<LibraryPage> getAlbums({
-    required String userId,
-    String? libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortBy = 'DateCreated,SortName',
-    String? contributingArtistIds,
-    String sortOrder = 'Descending',
-    List<String> artistIds = const [],
-    List<String> genreIds = const [],
-    List<String> filters = const [],
-    List<String> ids = const [],
-  });
+  MediaServerCapabilities get capabilities;
 
-  Future<LibraryPage> getArtists({
-    required String userId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortBy = 'SortName',
-    String sortOrder = 'Descending',
-    List<String> filters = const [],
-  });
+  Future<LibraryPage> getAlbums(LibraryQuery query);
 
-  Future<LibraryPage> getGenres({
-    required String userId,
-    String? libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortBy = 'SortName',
-    String sortOrder = 'Ascending',
-  });
+  Future<LibraryPage> getArtists(LibraryQuery query);
 
-  Future<LibraryPage> getPlaylists({
-    required String userId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortBy = 'DateCreated,SortName',
-    String? contributingArtistIds,
-    String sortOrder = 'Descending',
-    List<String> artistIds = const [],
-  });
+  Future<LibraryPage> getGenres(LibraryQuery query);
 
-  Future<LibraryPage> getAllSongs({
-    required String userId,
-    String? libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortBy = 'SortName',
-    String sortOrder = 'Ascending',
-    List<String> filters = const [],
-    List<String> fields = const ['MediaSources'],
-  });
+  Future<LibraryPage> getPlaylists(LibraryQuery query);
 
-  Future<LibraryPage> getSongs({
-    required String userId,
-    required String albumId,
-  });
+  Future<LibraryPage> getAllSongs(LibraryQuery query);
 
-  Future<LibraryPage> getSongsOfSet({
-    required String userId,
-    String? libraryId,
-    List<String> artistIds = const [],
-    List<String> genreIds = const [],
-    List<String> filters = const [],
-    String sortBy = 'AlbumArtist,Album,ParentIndexNumber,IndexNumber',
-    String sortOrder = 'Ascending',
-    String startIndex = '0',
-    String limit = '300',
-    List<String> fields = const ['MediaSources'],
-  });
+  Future<LibraryPage> getSongsOfSet(LibraryQuery query);
 
-  Future<LibraryPage> getPlaylistSongs({
-    required String userId,
-    required String playlistId,
-  });
+  Future<LibraryPage> getSongs(String albumId);
 
-  Future<LibraryPage> getSimilarAlbums({
-    required String userId,
-    required String albumId,
-    String limit = '12',
-  });
+  Future<LibraryPage> getPlaylistSongs(String playlistId);
+
+  Future<LibraryPage> getSimilarAlbums(String albumId, {int limit = 12});
 
   Future<List<GeneratedPlaylist>> generateTodaysPlaylists({
-    required String userId,
     String? libraryId,
     bool includeDiscovery = false,
   });
 
   Future<List<LibraryItem>> getGeneratedPlaylistSongs({
-    required String userId,
     required String playlistId,
     String? libraryId,
   });
 
-  Future<LibraryPage> getLibraries({required String userId});
+  Future<LibraryPage> getLibraries();
 
-  Future<LibraryItem> getItem(String itemId);
+  Future<LibraryItem> getItem(String itemId, {required ItemKind kind});
 
-  Future<LibraryPage> searchAlbums({
-    required String userId,
-    required String searchTerm,
-    String? libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortOrder = 'Descending',
-  });
+  Future<LibraryPage> searchAlbums(SearchQuery query);
 
-  Future<LibraryPage> searchArtists({
-    required String userId,
-    required String searchTerm,
-    String startIndex = '0',
-    String limit = '100',
-    String sortOrder = 'Descending',
-  });
+  Future<LibraryPage> searchArtists(SearchQuery query);
 
-  Future<LibraryPage> searchSongs({
-    required String userId,
-    required String searchTerm,
-    String? libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortOrder = 'Descending',
-  });
+  Future<LibraryPage> searchSongs(SearchQuery query);
 
-  Future<LibraryPage> searchPlaylists({
-    required String userId,
-    required String searchTerm,
-    required String libraryId,
-    String startIndex = '0',
-    String limit = '100',
-    String sortOrder = 'Descending',
-  });
+  Future<LibraryPage> searchPlaylists(SearchQuery query);
 
   Future<void> setFavorite(String itemId, {required bool favorite});
 
@@ -157,7 +67,7 @@ abstract class MediaServerClient {
     required String entryId,
   });
 
-  Future<LyricsDTO> getLyrics(String itemId);
+  Future<Lyrics?> getLyrics(String itemId);
 
   Future<StreamSource> resolveStreamSource(
     LibraryItem song, {

--- a/lib/src/data/backend/media_server_exception.dart
+++ b/lib/src/data/backend/media_server_exception.dart
@@ -1,0 +1,58 @@
+import 'package:dio/dio.dart';
+
+enum MediaServerErrorKind {
+  unauthorized,
+  notFound,
+  unavailable,
+  transport,
+  server,
+}
+
+class MediaServerException implements Exception {
+  const MediaServerException(this.kind, {this.statusCode, this.message});
+
+  factory MediaServerException.fromDio(DioException error) {
+    final statusCode = error.response?.statusCode;
+    return MediaServerException(
+      _kindOf(error, statusCode),
+      statusCode: statusCode,
+      message: error.message,
+    );
+  }
+
+  final MediaServerErrorKind kind;
+  final int? statusCode;
+  final String? message;
+
+  static MediaServerErrorKind _kindOf(DioException error, int? statusCode) {
+    switch (error.type) {
+      case DioExceptionType.badResponse:
+        if (statusCode == 401 || statusCode == 403) {
+          return MediaServerErrorKind.unauthorized;
+        }
+        if (statusCode == 404 || statusCode == 400) {
+          return MediaServerErrorKind.notFound;
+        }
+        return MediaServerErrorKind.server;
+
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
+      case DioExceptionType.connectionError:
+      case DioExceptionType.badCertificate:
+        return MediaServerErrorKind.unavailable;
+
+      case DioExceptionType.cancel:
+      case DioExceptionType.unknown:
+        return MediaServerErrorKind.transport;
+    }
+  }
+
+  bool get isUnauthorized => kind == MediaServerErrorKind.unauthorized;
+
+  bool get isNotFound => kind == MediaServerErrorKind.notFound;
+
+  @override
+  String toString() =>
+      message ?? 'MediaServerException(${kind.name}, status: $statusCode)';
+}

--- a/lib/src/data/backend/mediabrowser_authenticator.dart
+++ b/lib/src/data/backend/mediabrowser_authenticator.dart
@@ -1,0 +1,26 @@
+import 'package:jplayer/src/data/backend/server_session.dart';
+import 'package:jplayer/src/data/dto/dto.dart';
+import 'package:jplayer/src/data/params/params.dart';
+
+abstract class MediaBrowserAuthenticator extends MediaServerAuthenticator {
+  const MediaBrowserAuthenticator();
+
+  Future<SignInResultDTO> authenticate(
+    UserCredentials credentials, {
+    required String serverUrl,
+  });
+
+  @override
+  Future<ServerSession> signIn(
+    UserCredentials credentials, {
+    required String serverUrl,
+  }) async {
+    final result = await authenticate(credentials, serverUrl: serverUrl);
+    return ServerSession(
+      userId: result.user.id,
+      token: result.accessToken,
+      serverId: result.serverId.isNotEmpty ? result.serverId : serverUrl,
+      serverName: result.user.name,
+    );
+  }
+}

--- a/lib/src/data/backend/mediabrowser_probe.dart
+++ b/lib/src/data/backend/mediabrowser_probe.dart
@@ -1,0 +1,107 @@
+import 'package:dio/dio.dart';
+import 'package:jplayer/src/data/api/api.dart';
+import 'package:jplayer/src/data/backend/server_identity.dart';
+import 'package:jplayer/src/data/backend/server_probe.dart';
+import 'package:jplayer/src/data/backend/server_type.dart';
+import 'package:jplayer/src/data/dto/dto.dart';
+
+const embyPathPrefix = '/emby';
+
+String _withoutTrailingSlash(String url) => url.replaceAll(RegExp(r'/+$'), '');
+
+List<String> serverPathCandidates(String serverUrl) {
+  final trimmed = _withoutTrailingSlash(serverUrl);
+  if (trimmed.toLowerCase().endsWith(embyPathPrefix)) return [trimmed];
+  return [trimmed, '$trimmed$embyPathPrefix'];
+}
+
+ServerType? serverTypeFromProductName(String? productName) {
+  final product = productName?.toLowerCase() ?? '';
+  if (product.contains('jellyfin')) return ServerType.jellyfin;
+  if (product.contains('emby')) return ServerType.emby;
+  return null;
+}
+
+ServerType serverTypeOf(
+  PublicSystemInfoDTO info, {
+  required String serverUrl,
+}) {
+  final named = serverTypeFromProductName(info.productName);
+  if (named != null) return named;
+  if (serverUrl.toLowerCase().endsWith(embyPathPrefix)) return ServerType.emby;
+  final reportsAddressLists =
+      info.localAddresses != null || info.remoteAddresses != null;
+  return reportsAddressLists ? ServerType.emby : ServerType.jellyfin;
+}
+
+class MediaBrowserProbe extends ServerProbe {
+  const MediaBrowserProbe(this._client);
+
+  final Dio _client;
+
+  @override
+  ServerType get serverType => ServerType.jellyfin;
+
+  @override
+  List<String> pathCandidates(String serverUrl) =>
+      serverPathCandidates(serverUrl);
+
+  @override
+  Future<ServerIdentity?> identify(String serverUrl) async {
+    final info = await publicInfo(serverUrl);
+    if (info == null) return null;
+    return ServerIdentity(
+      serverUrl: serverUrl,
+      serverType: await resolveServerType(info, serverUrl: serverUrl),
+      serverId: info.id,
+      name: info.serverName,
+      version: info.version,
+      productName: info.productName,
+    );
+  }
+
+  @override
+  Future<ServerType?> identifyType(String serverUrl) async {
+    final info = await publicInfo(serverUrl);
+    if (info != null) return resolveServerType(info, serverUrl: serverUrl);
+    return serverTypeFromProductName(await ping(serverUrl));
+  }
+
+  Future<ServerType> resolveServerType(
+    PublicSystemInfoDTO info, {
+    required String serverUrl,
+  }) async {
+    final fromInfo = serverTypeFromProductName(info.productName);
+    if (fromInfo != null) return fromInfo;
+
+    final fromPing = serverTypeFromProductName(await ping(serverUrl));
+    if (fromPing != null) return fromPing;
+
+    return serverTypeOf(info, serverUrl: serverUrl);
+  }
+
+  Future<String?> ping(String serverUrl) async {
+    try {
+      final response = await _client.get<String>(
+        '$serverUrl/System/Ping',
+        options: Options(responseType: ResponseType.plain),
+      );
+      return response.data;
+    } on Object {
+      return null;
+    }
+  }
+
+  Future<PublicSystemInfoDTO?> publicInfo(String serverUrl) async {
+    try {
+      final response = await JellyfinApi(
+        _client,
+        baseUrl: serverUrl,
+      ).getPublicSystemInfo();
+      final info = response.data;
+      return (info.id != null && info.version != null) ? info : null;
+    } on Object {
+      return null;
+    }
+  }
+}

--- a/lib/src/data/backend/mediabrowser_query.dart
+++ b/lib/src/data/backend/mediabrowser_query.dart
@@ -1,0 +1,36 @@
+import 'package:jplayer/src/data/backend/library_query.dart';
+import 'package:jplayer/src/domain/models/models.dart';
+
+String mediaBrowserSort(ItemSort sort, {ItemKind target = ItemKind.album}) =>
+    switch (sort) {
+      ItemSort.name => target == ItemKind.song ? 'Name' : 'SortName',
+      ItemSort.albumArtist => 'AlbumArtist',
+      ItemSort.dateCreated => 'DateCreated,SortName',
+      ItemSort.datePlayed => 'DatePlayed',
+      ItemSort.playCount => 'PlayCount',
+      ItemSort.dateLastContentAdded => 'DateLastContentAdded',
+      ItemSort.albumOrder => 'AlbumArtist,Album,ParentIndexNumber,IndexNumber',
+      ItemSort.random => 'Random',
+    };
+
+String mediaBrowserSortOrder(SortDirection direction) => switch (direction) {
+  SortDirection.ascending => 'Ascending',
+  SortDirection.descending => 'Descending',
+};
+
+List<String> mediaBrowserFilters(Set<ItemFilterFlag> filters) => [
+  for (final flag in filters)
+    switch (flag) {
+      ItemFilterFlag.favorite => 'IsFavorite',
+      ItemFilterFlag.played => 'IsPlayed',
+      ItemFilterFlag.unplayed => 'IsUnplayed',
+    },
+];
+
+List<String> mediaBrowserFields(Set<ItemField> fields) => [
+  for (final field in fields)
+    switch (field) {
+      ItemField.audioSources => 'MediaSources',
+      ItemField.genres => 'Genres',
+    },
+];

--- a/lib/src/data/backend/server_auth_headers.dart
+++ b/lib/src/data/backend/server_auth_headers.dart
@@ -34,6 +34,20 @@ String mediaBrowserCredentials({
   return 'MediaBrowser ${fields.join(', ')}';
 }
 
+class NoServerAuthHeaders extends ServerAuthHeaders {
+  const NoServerAuthHeaders({
+    super.deviceId = '',
+    super.deviceName = '',
+    super.version = '',
+  });
+
+  @override
+  Set<String> get managedKeys => const {};
+
+  @override
+  Map<String, String> build({String? token}) => const {};
+}
+
 abstract class ServerAuthHeaders {
   const ServerAuthHeaders({
     required this.deviceId,

--- a/lib/src/data/backend/server_identity.dart
+++ b/lib/src/data/backend/server_identity.dart
@@ -1,0 +1,19 @@
+import 'package:jplayer/src/data/backend/server_type.dart';
+
+class ServerIdentity {
+  const ServerIdentity({
+    required this.serverUrl,
+    required this.serverType,
+    this.serverId,
+    this.name,
+    this.version,
+    this.productName,
+  });
+
+  final String serverUrl;
+  final ServerType serverType;
+  final String? serverId;
+  final String? name;
+  final String? version;
+  final String? productName;
+}

--- a/lib/src/data/backend/server_probe.dart
+++ b/lib/src/data/backend/server_probe.dart
@@ -1,0 +1,14 @@
+import 'package:jplayer/src/data/backend/server_identity.dart';
+import 'package:jplayer/src/data/backend/server_type.dart';
+
+abstract class ServerProbe {
+  const ServerProbe();
+
+  ServerType get serverType;
+
+  List<String> pathCandidates(String serverUrl);
+
+  Future<ServerIdentity?> identify(String serverUrl);
+
+  Future<ServerType?> identifyType(String serverUrl);
+}

--- a/lib/src/data/backend/server_session.dart
+++ b/lib/src/data/backend/server_session.dart
@@ -1,0 +1,25 @@
+import 'package:jplayer/src/data/params/params.dart';
+
+class ServerSession {
+  const ServerSession({
+    required this.userId,
+    required this.token,
+    required this.serverId,
+    this.serverName,
+  });
+
+  final String userId;
+  final String token;
+  final String serverId;
+  final String? serverName;
+}
+
+// ignore: one_member_abstracts
+abstract class MediaServerAuthenticator {
+  const MediaServerAuthenticator();
+
+  Future<ServerSession> signIn(
+    UserCredentials credentials, {
+    required String serverUrl,
+  });
+}

--- a/lib/src/data/backend/server_type.dart
+++ b/lib/src/data/backend/server_type.dart
@@ -1,0 +1,9 @@
+enum ServerType {
+  jellyfin,
+  emby;
+
+  String get label => switch (this) {
+    ServerType.jellyfin => 'Jellyfin',
+    ServerType.emby => 'Emby',
+  };
+}

--- a/lib/src/data/providers/media_server_client_provider.dart
+++ b/lib/src/data/providers/media_server_client_provider.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:jplayer/main.dart';
-import 'package:jplayer/src/data/backend/emby/emby_client.dart';
-import 'package:jplayer/src/data/backend/jellyfin/jellyfin_client.dart';
+import 'package:jplayer/src/data/backend/media_server_backends.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
 import 'package:jplayer/src/data/services/server_probe_service.dart';
@@ -14,23 +13,12 @@ final mediaServerClientProvider = Provider<MediaServerClient>((ref) {
   final baseUrl = ref.watch(baseUrlProvider) ?? '';
   final serverType =
       ref.watch(currentServerTypeProvider) ?? ServerType.jellyfin;
-  switch (serverType) {
-    case ServerType.jellyfin:
-      return JellyfinClient(
-        dio: ref.watch(dioProvider),
-        baseUrl: baseUrl,
-        userId: user?.userId ?? '',
-        token: user?.token ?? '',
-        deviceId: deviceId,
-      );
-
-    case ServerType.emby:
-      return EmbyClient(
-        dio: ref.watch(dioProvider),
-        baseUrl: baseUrl,
-        userId: user?.userId ?? '',
-        token: user?.token ?? '',
-        deviceId: deviceId,
-      );
-  }
+  return clientFor(
+    serverType,
+    dio: ref.watch(dioProvider),
+    baseUrl: baseUrl,
+    userId: user?.userId ?? '',
+    token: user?.token ?? '',
+    deviceId: deviceId,
+  );
 });

--- a/lib/src/data/services/server_probe_service.dart
+++ b/lib/src/data/services/server_probe_service.dart
@@ -1,6 +1,13 @@
 import 'package:dio/dio.dart';
-import 'package:jplayer/src/data/api/api.dart';
-import 'package:jplayer/src/data/dto/dto.dart';
+import 'package:jplayer/src/data/backend/media_server_backends.dart';
+import 'package:jplayer/src/data/backend/server_identity.dart';
+import 'package:jplayer/src/data/backend/server_probe.dart';
+import 'package:jplayer/src/data/backend/server_type.dart';
+
+export 'package:jplayer/src/data/backend/mediabrowser_probe.dart'
+    show embyPathPrefix, serverPathCandidates, serverTypeFromProductName;
+export 'package:jplayer/src/data/backend/server_identity.dart';
+export 'package:jplayer/src/data/backend/server_type.dart';
 
 final _schemeRegExp = RegExp('^https?://', caseSensitive: false);
 
@@ -17,121 +24,45 @@ List<String> serverUrlCandidates(String url) {
   return ['http://$trimmed', 'https://$trimmed'];
 }
 
-enum ServerType {
-  jellyfin,
-  emby;
-
-  String get label => switch (this) {
-    ServerType.jellyfin => 'Jellyfin',
-    ServerType.emby => 'Emby',
-  };
-}
-
-const embyPathPrefix = '/emby';
-
-String _withoutTrailingSlash(String url) => url.replaceAll(RegExp(r'/+$'), '');
-
-List<String> serverPathCandidates(String serverUrl) {
-  final trimmed = _withoutTrailingSlash(serverUrl);
-  if (trimmed.toLowerCase().endsWith(embyPathPrefix)) return [trimmed];
-  return [trimmed, '$trimmed$embyPathPrefix'];
-}
-
-ServerType? serverTypeFromProductName(String? productName) {
-  final product = productName?.toLowerCase() ?? '';
-  if (product.contains('jellyfin')) return ServerType.jellyfin;
-  if (product.contains('emby')) return ServerType.emby;
-  return null;
-}
-
-ServerType serverTypeOf(
-  PublicSystemInfoDTO info, {
-  required String serverUrl,
-}) {
-  final named = serverTypeFromProductName(info.productName);
-  if (named != null) return named;
-  if (serverUrl.toLowerCase().endsWith(embyPathPrefix)) return ServerType.emby;
-  final reportsAddressLists =
-      info.localAddresses != null || info.remoteAddresses != null;
-  return reportsAddressLists ? ServerType.emby : ServerType.jellyfin;
-}
-
-class ServerProbeResult {
-  const ServerProbeResult({
-    required this.serverUrl,
-    required this.serverType,
-    required this.info,
-  });
-
-  final String serverUrl;
-  final ServerType serverType;
-  final PublicSystemInfoDTO info;
-}
+Dio defaultProbeClient() => Dio(
+  BaseOptions(
+    connectTimeout: const Duration(seconds: 6),
+    receiveTimeout: const Duration(seconds: 6),
+    contentType: 'application/json',
+  ),
+);
 
 class ServerProbeService {
-  ServerProbeService({Dio? client})
-    : _client =
-          client ??
-          Dio(
-            BaseOptions(
-              connectTimeout: const Duration(seconds: 6),
-              receiveTimeout: const Duration(seconds: 6),
-              contentType: 'application/json',
-            ),
-          );
+  ServerProbeService({Dio? client, List<ServerProbe>? probes})
+    : _probes = probes ?? defaultServerProbes(client ?? defaultProbeClient());
 
-  final Dio _client;
+  final List<ServerProbe> _probes;
 
-  Future<ServerProbeResult?> discover(String url) async {
+  Future<ServerIdentity?> discover(String url) async {
     for (final candidate in serverUrlCandidates(url)) {
-      for (final serverUrl in serverPathCandidates(candidate)) {
-        final info = await probe(serverUrl);
-        if (info == null) continue;
-        return ServerProbeResult(
-          serverUrl: serverUrl,
-          serverType: await resolveServerType(info, serverUrl: serverUrl),
-          info: info,
-        );
+      for (final probe in _probes) {
+        for (final serverUrl in probe.pathCandidates(candidate)) {
+          final identity = await probe.identify(serverUrl);
+          if (identity != null) return identity;
+        }
       }
     }
     return null;
   }
 
-  Future<ServerType> resolveServerType(
-    PublicSystemInfoDTO info, {
-    required String serverUrl,
-  }) async {
-    final fromInfo = serverTypeFromProductName(info.productName);
-    if (fromInfo != null) return fromInfo;
-
-    final fromPing = serverTypeFromProductName(await ping(serverUrl));
-    if (fromPing != null) return fromPing;
-
-    return serverTypeOf(info, serverUrl: serverUrl);
+  Future<ServerIdentity?> probe(String serverUrl) async {
+    for (final probe in _probes) {
+      final identity = await probe.identify(serverUrl);
+      if (identity != null) return identity;
+    }
+    return null;
   }
 
-  Future<String?> ping(String serverUrl) async {
-    try {
-      final response = await _client.get<String>(
-        '$serverUrl/System/Ping',
-        options: Options(responseType: ResponseType.plain),
-      );
-      return response.data;
-    } on Object {
-      return null;
+  Future<ServerType?> detectType(String serverUrl) async {
+    for (final probe in _probes) {
+      final serverType = await probe.identifyType(serverUrl);
+      if (serverType != null) return serverType;
     }
-  }
-
-  Future<PublicSystemInfoDTO?> probe(String serverUrl) async {
-    try {
-      final response = await JellyfinApi(
-        _client,
-        baseUrl: serverUrl,
-      ).getPublicSystemInfo();
-      final info = response.data;
-      return (info.id != null && info.version != null) ? info : null;
-    } on Object {
-      return null;
-    }
+    return null;
   }
 }

--- a/lib/src/domain/models/lyrics/lyrics.dart
+++ b/lib/src/domain/models/lyrics/lyrics.dart
@@ -1,0 +1,37 @@
+class Lyrics {
+  const Lyrics({
+    this.lines = const [],
+    this.isSynced = false,
+    this.offset = Duration.zero,
+  });
+
+  final List<LyricLine> lines;
+  final bool isSynced;
+  final Duration offset;
+
+  bool get isEmpty => lines.isEmpty;
+
+  bool get hasWordCues => lines.any((line) => line.cues.isNotEmpty);
+}
+
+class LyricLine {
+  const LyricLine({this.text = '', this.start, this.cues = const []});
+
+  final String text;
+  final Duration? start;
+  final List<LyricCue> cues;
+}
+
+class LyricCue {
+  const LyricCue({
+    required this.start,
+    this.end,
+    this.position = 0,
+    this.endPosition = 0,
+  });
+
+  final Duration start;
+  final Duration? end;
+  final int position;
+  final int endPosition;
+}

--- a/lib/src/domain/models/models.dart
+++ b/lib/src/domain/models/models.dart
@@ -10,4 +10,5 @@ export 'library_item/item_kind.dart';
 export 'library_item/library_item.dart';
 export 'library_item/library_page.dart';
 export 'library_item/playback_user_data.dart';
+export 'lyrics/lyrics.dart';
 export 'playback_state/playback_state.dart';

--- a/lib/src/domain/providers/current_album_provider.dart
+++ b/lib/src/domain/providers/current_album_provider.dart
@@ -5,7 +5,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
 import 'package:jplayer/src/domain/models/models.dart';
-import 'package:jplayer/src/domain/providers/current_user_provider.dart';
 
 class CurrentAlbumNotifier extends StateNotifier<LibraryItem?> {
   CurrentAlbumNotifier(this._ref) : super(null) {
@@ -25,10 +24,7 @@ class CurrentAlbumNotifier extends StateNotifier<LibraryItem?> {
   // TODO: should be moved to a separate provider
   Future<LibraryPage> fetchSongs(String albumId) async {
     try {
-      return await _client.getSongs(
-        userId: _ref.read(currentUserProvider)!.userId,
-        albumId: albumId,
-      );
+      return await _client.getSongs(albumId);
     } on DioException catch (e) {
       log(e.message ?? 'Error while fetching Songs');
     }

--- a/lib/src/domain/providers/current_playlist_provider.dart
+++ b/lib/src/domain/providers/current_playlist_provider.dart
@@ -5,7 +5,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
 import 'package:jplayer/src/domain/models/models.dart';
-import 'package:jplayer/src/domain/providers/current_user_provider.dart';
 
 class CurrentPlaylistNotifier extends StateNotifier<LibraryItem?> {
   CurrentPlaylistNotifier(this._ref) : super(null) {
@@ -25,10 +24,7 @@ class CurrentPlaylistNotifier extends StateNotifier<LibraryItem?> {
   // TODO: should be moved to a separate provider
   Future<LibraryPage> fetchSongs(String playlistId) async {
     try {
-      return await _client.getSongs(
-        userId: _ref.read(currentUserProvider)!.userId,
-        albumId: playlistId,
-      );
+      return await _client.getSongs(playlistId);
     } on DioException catch (e) {
       log(e.message ?? 'Error while fetching Songs');
     }

--- a/lib/src/domain/providers/discovered_servers_provider.dart
+++ b/lib/src/domain/providers/discovered_servers_provider.dart
@@ -91,9 +91,7 @@ class ServerDiscoveryNotifier extends StateNotifier<ServerDiscoveryState> {
     final server = DiscoveredServer(
       id: announcement.id,
       name:
-          result.info.serverName ??
-          announcement.name ??
-          Uri.parse(result.serverUrl).host,
+          result.name ?? announcement.name ?? Uri.parse(result.serverUrl).host,
       serverUrl: result.serverUrl,
       serverType: result.serverType,
     );
@@ -108,7 +106,7 @@ class ServerDiscoveryNotifier extends StateNotifier<ServerDiscoveryState> {
     state = state.copyWith(scanning: false, finished: true);
   }
 
-  Future<ServerProbeResult?> _probeSourceAddress(
+  Future<ServerIdentity?> _probeSourceAddress(
     ServerAnnouncement announcement,
   ) async {
     final source = announcement.sourceAddress;

--- a/lib/src/domain/providers/favourites_provider.dart
+++ b/lib/src/domain/providers/favourites_provider.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:jplayer/src/core/enums/enums.dart';
+import 'package:jplayer/src/data/backend/library_query.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
 import 'package:jplayer/src/core/exceptions/exceptions.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
@@ -9,7 +9,6 @@ import 'package:jplayer/src/domain/models/models.dart';
 import 'package:jplayer/src/domain/providers/current_library_provider.dart';
 import 'package:jplayer/src/domain/providers/current_user_provider.dart';
 import 'package:jplayer/src/providers/connectivity_provider.dart';
-import 'package:string_capitalize/string_capitalize.dart';
 
 const favouritesLimit = 100;
 
@@ -21,7 +20,7 @@ const likedSongsPlaylist = LibraryItem(
   kind: ItemKind.playlist,
 );
 
-const _favouriteFilter = ['IsFavorite'];
+const _favouriteFilter = {ItemFilterFlag.favorite};
 
 final AutoDisposeFutureProvider<List<LibraryItem>> favouriteAlbumsProvider =
     FutureProvider.autoDispose((ref) async {
@@ -31,12 +30,11 @@ final AutoDisposeFutureProvider<List<LibraryItem>> favouriteAlbumsProvider =
       if (userId == null) return const [];
 
       final page = await api.getAlbums(
-        userId: userId,
-        libraryId: ref.watch(currentLibraryProvider).valueOrNull?.id,
-        sortBy: 'SortName',
-        sortOrder: 'Ascending',
-        filters: _favouriteFilter,
-        limit: '$favouritesLimit',
+        LibraryQuery(
+          libraryId: ref.watch(currentLibraryProvider).valueOrNull?.id,
+          filters: _favouriteFilter,
+          limit: favouritesLimit,
+        ),
       );
       return page.items;
     });
@@ -49,11 +47,7 @@ final AutoDisposeFutureProvider<List<LibraryItem>> favouriteArtistsProvider =
       if (userId == null) return const [];
 
       final page = await api.getArtists(
-        userId: userId,
-        sortBy: 'SortName',
-        sortOrder: 'Ascending',
-        filters: _favouriteFilter,
-        limit: '$favouritesLimit',
+        const LibraryQuery(filters: _favouriteFilter, limit: favouritesLimit),
       );
       return page.items;
     });
@@ -66,12 +60,11 @@ final AutoDisposeFutureProvider<LibraryPage> favouriteSongsProvider =
       if (userId == null) return const LibraryPage();
 
       return api.getAllSongs(
-        userId: userId,
-        libraryId: ref.watch(currentLibraryProvider).valueOrNull?.id,
-        sortBy: 'SortName',
-        sortOrder: 'Ascending',
-        filters: _favouriteFilter,
-        limit: '$favouritesLimit',
+        LibraryQuery(
+          libraryId: ref.watch(currentLibraryProvider).valueOrNull?.id,
+          filters: _favouriteFilter,
+          limit: favouritesLimit,
+        ),
       );
     });
 
@@ -114,14 +107,13 @@ class FavouriteSongsNotifier
     if (userId == null) return startPage;
 
     final page = await _api.getAllSongs(
-      userId: userId,
-      libraryId: _libraryId,
-      sortBy: arg.orderBy == EntityFilter.sortName
-          ? 'Name'
-          : arg.orderBy.name.capitalize(),
-      sortOrder: arg.desc ? 'Descending' : 'Ascending',
-      filters: _favouriteFilter,
-      startIndex: '$startIndex',
+      LibraryQuery(
+        libraryId: _libraryId,
+        sort: arg.orderBy.itemSort,
+        direction: sortDirectionOf(descending: arg.desc),
+        filters: _favouriteFilter,
+        startIndex: startIndex,
+      ),
     );
     return startPage.copyWith(
       items: [...startPage.items, ...page.items],

--- a/lib/src/domain/providers/genre_albums_provider.dart
+++ b/lib/src/domain/providers/genre_albums_provider.dart
@@ -2,11 +2,11 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:jplayer/src/core/exceptions/exceptions.dart';
+import 'package:jplayer/src/data/backend/library_query.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
 import 'package:jplayer/src/domain/models/models.dart';
 import 'package:jplayer/src/domain/providers/current_library_provider.dart';
-import 'package:jplayer/src/domain/providers/current_user_provider.dart';
 import 'package:jplayer/src/providers/connectivity_provider.dart';
 
 class GenreAlbumsNotifier
@@ -27,12 +27,11 @@ class GenreAlbumsNotifier
     ItemsPage startPage = const ItemsPage(),
   }) async {
     final resp = await _client.getAlbums(
-      userId: ref.read(currentUserProvider)!.userId,
-      libraryId: _libraryId,
-      genreIds: [arg],
-      sortBy: 'SortName',
-      sortOrder: 'Ascending',
-      startIndex: startIndex.toString(),
+      LibraryQuery(
+        libraryId: _libraryId,
+        genreIds: [arg],
+        startIndex: startIndex,
+      ),
     );
     return startPage.copyWith(
       items: [...startPage.items, ...resp.items],

--- a/lib/src/domain/providers/home_sections_provider.dart
+++ b/lib/src/domain/providers/home_sections_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:jplayer/src/core/exceptions/exceptions.dart';
+import 'package:jplayer/src/data/backend/library_query.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
 import 'package:jplayer/src/domain/models/models.dart';
@@ -13,14 +14,11 @@ const _playedSongsScanLimit = 200;
 
 Future<List<LibraryItem>> _albumsByIds(
   MediaServerClient api,
-  String userId,
   List<String> albumIds,
 ) async {
   if (albumIds.isEmpty) return const [];
   final albums = await api.getAlbums(
-    userId: userId,
-    ids: albumIds,
-    limit: '${albumIds.length}',
+    LibraryQuery(ids: albumIds, limit: albumIds.length),
   );
   final byId = {for (final album in albums.items) album.id: album};
   return [for (final id in albumIds) ?byId[id]];
@@ -34,12 +32,13 @@ recentlyPlayedAlbumsProvider = FutureProvider.autoDispose((ref) async {
   if (userId == null) return const [];
 
   final played = await api.getAllSongs(
-    userId: userId,
-    libraryId: ref.watch(currentLibraryProvider).valueOrNull?.id,
-    sortBy: 'DatePlayed',
-    sortOrder: 'Descending',
-    filters: const ['IsPlayed'],
-    limit: '$_playedSongsScanLimit',
+    LibraryQuery(
+      libraryId: ref.watch(currentLibraryProvider).valueOrNull?.id,
+      sort: ItemSort.datePlayed,
+      direction: SortDirection.descending,
+      filters: const {ItemFilterFlag.played},
+      limit: _playedSongsScanLimit,
+    ),
   );
 
   final albumIds = <String>[];
@@ -50,7 +49,7 @@ recentlyPlayedAlbumsProvider = FutureProvider.autoDispose((ref) async {
     if (albumIds.length == homeSectionLimit) break;
   }
 
-  return _albumsByIds(api, userId, albumIds);
+  return _albumsByIds(api, albumIds);
 });
 
 final AutoDisposeFutureProvider<List<LibraryItem>>
@@ -61,12 +60,13 @@ frequentlyPlayedAlbumsProvider = FutureProvider.autoDispose((ref) async {
   if (userId == null) return const [];
 
   final played = await api.getAllSongs(
-    userId: userId,
-    libraryId: ref.watch(currentLibraryProvider).valueOrNull?.id,
-    sortBy: 'PlayCount',
-    sortOrder: 'Descending',
-    filters: const ['IsPlayed'],
-    limit: '$_playedSongsScanLimit',
+    LibraryQuery(
+      libraryId: ref.watch(currentLibraryProvider).valueOrNull?.id,
+      sort: ItemSort.playCount,
+      direction: SortDirection.descending,
+      filters: const {ItemFilterFlag.played},
+      limit: _playedSongsScanLimit,
+    ),
   );
 
   final playsPerAlbum = <String, int>{};
@@ -83,11 +83,7 @@ frequentlyPlayedAlbumsProvider = FutureProvider.autoDispose((ref) async {
   final albumIds = playsPerAlbum.keys.toList()
     ..sort((a, b) => playsPerAlbum[b]!.compareTo(playsPerAlbum[a]!));
 
-  return _albumsByIds(
-    api,
-    userId,
-    albumIds.take(homeSectionLimit).toList(),
-  );
+  return _albumsByIds(api, albumIds.take(homeSectionLimit).toList());
 });
 
 final AutoDisposeFutureProvider<List<LibraryItem>> recentlyAddedAlbumsProvider =
@@ -98,10 +94,12 @@ final AutoDisposeFutureProvider<List<LibraryItem>> recentlyAddedAlbumsProvider =
       if (userId == null) return const [];
 
       final page = await api.getAlbums(
-        userId: userId,
-        libraryId: ref.watch(currentLibraryProvider).valueOrNull?.id,
-        sortBy: 'DateCreated',
-        limit: '$homeSectionLimit',
+        LibraryQuery(
+          libraryId: ref.watch(currentLibraryProvider).valueOrNull?.id,
+          sort: ItemSort.dateCreated,
+          direction: SortDirection.descending,
+          limit: homeSectionLimit,
+        ),
       );
       return page.items;
     });
@@ -114,9 +112,11 @@ recentlyUpdatedPlaylistsProvider = FutureProvider.autoDispose((ref) async {
   if (userId == null) return const [];
 
   final page = await api.getPlaylists(
-    userId: userId,
-    sortBy: 'DateLastContentAdded',
-    limit: '$homeSectionLimit',
+    const LibraryQuery(
+      sort: ItemSort.dateLastContentAdded,
+      direction: SortDirection.descending,
+      limit: homeSectionLimit,
+    ),
   );
   return page.items;
 });

--- a/lib/src/domain/providers/item_list_providers.dart
+++ b/lib/src/domain/providers/item_list_providers.dart
@@ -3,20 +3,22 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:jplayer/src/core/enums/enums.dart';
 import 'package:jplayer/src/core/exceptions/exceptions.dart';
+import 'package:jplayer/src/data/backend/library_query.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
 import 'package:jplayer/src/domain/models/models.dart';
 import 'package:jplayer/src/domain/providers/current_library_provider.dart';
-import 'package:jplayer/src/domain/providers/current_user_provider.dart';
 import 'package:jplayer/src/domain/providers/items_filter_provider.dart';
 import 'package:jplayer/src/providers/connectivity_provider.dart';
-import 'package:string_capitalize/string_capitalize.dart';
 
 class ItemListNotifier
     extends AutoDisposeFamilyAsyncNotifier<ItemsPage, ItemList> {
   late MediaServerClient _api;
   late Filter _filterState;
   String? _libraryId;
+
+  SortDirection get _direction =>
+      sortDirectionOf(descending: _filterState.desc);
 
   @override
   FutureOr<ItemsPage> build(ItemList arg) async {
@@ -33,41 +35,42 @@ class ItemListNotifier
   }) async {
     final resp = await switch (arg) {
       ItemList.albums => _api.getAlbums(
-        userId: ref.read(currentUserProvider)!.userId,
-        libraryId: _libraryId,
-        sortOrder: _filterState.desc ? 'Descending' : 'Ascending',
-        sortBy: _filterState.orderBy.name.capitalize(),
-        startIndex: startIndex.toString(),
+        LibraryQuery(
+          libraryId: _libraryId,
+          sort: _filterState.orderBy.itemSort,
+          direction: _direction,
+          startIndex: startIndex,
+        ),
       ),
       ItemList.artists => _api.getArtists(
-        userId: ref.read(currentUserProvider)!.userId,
-        sortOrder: _filterState.desc ? 'Descending' : 'Ascending',
-        sortBy: _filterState.orderBy.name.capitalize(),
-        startIndex: startIndex.toString(),
+        LibraryQuery(
+          sort: _filterState.orderBy.itemSort,
+          direction: _direction,
+          startIndex: startIndex,
+        ),
       ),
       ItemList.genres => _api.getGenres(
-        userId: ref.read(currentUserProvider)!.userId,
-        libraryId: _libraryId,
-        sortOrder: _filterState.desc ? 'Descending' : 'Ascending',
-        sortBy: _filterState.orderBy == EntityFilter.sortName
-            ? 'SortName'
-            : _filterState.orderBy.name.capitalize(),
-        startIndex: startIndex.toString(),
+        LibraryQuery(
+          libraryId: _libraryId,
+          sort: _filterState.orderBy.itemSort,
+          direction: _direction,
+          startIndex: startIndex,
+        ),
       ),
       ItemList.playlists => _api.getPlaylists(
-        userId: ref.read(currentUserProvider)!.userId,
-        sortOrder: _filterState.desc ? 'Descending' : 'Ascending',
-        sortBy: _filterState.orderBy.name.capitalize(),
-        startIndex: startIndex.toString(),
+        LibraryQuery(
+          sort: _filterState.orderBy.itemSort,
+          direction: _direction,
+          startIndex: startIndex,
+        ),
       ),
       ItemList.songs => _api.getAllSongs(
-        userId: ref.read(currentUserProvider)!.userId,
-        libraryId: _libraryId,
-        sortOrder: _filterState.desc ? 'Descending' : 'Ascending',
-        sortBy: _filterState.orderBy == EntityFilter.sortName
-            ? 'Name'
-            : _filterState.orderBy.name.capitalize(),
-        startIndex: startIndex.toString(),
+        LibraryQuery(
+          libraryId: _libraryId,
+          sort: _filterState.orderBy.itemSort,
+          direction: _direction,
+          startIndex: startIndex,
+        ),
       ),
     };
     return startPage.copyWith(

--- a/lib/src/domain/providers/libraries_provider.dart
+++ b/lib/src/domain/providers/libraries_provider.dart
@@ -5,7 +5,6 @@ import 'package:jplayer/src/core/exceptions/exceptions.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
 import 'package:jplayer/src/domain/models/models.dart';
-import 'package:jplayer/src/domain/providers/providers.dart';
 import 'package:jplayer/src/providers/connectivity_provider.dart';
 
 class LibrariesNotifier extends AutoDisposeAsyncNotifier<List<LibraryItem>> {
@@ -17,9 +16,7 @@ class LibrariesNotifier extends AutoDisposeAsyncNotifier<List<LibraryItem>> {
     _client = ref.watch(mediaServerClientProvider);
     state = const AsyncLoading();
     try {
-      final libraries = await _client.getLibraries(
-        userId: ref.read(currentUserProvider)!.userId,
-      );
+      final libraries = await _client.getLibraries();
       return List.unmodifiable(
         libraries.items.where(
           (element) =>

--- a/lib/src/domain/providers/lyrics_provider.dart
+++ b/lib/src/domain/providers/lyrics_provider.dart
@@ -1,27 +1,16 @@
-import 'dart:developer';
-
-import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:jplayer/src/data/dto/dto.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
+import 'package:jplayer/src/domain/models/models.dart';
 import 'package:jplayer/src/domain/providers/playback_provider.dart';
 import 'package:jplayer/src/domain/providers/studio_mode_provider.dart';
 import 'package:jplayer/src/providers/connectivity_provider.dart';
 
-final lyricsProvider = FutureProviderFamily<LyricsDTO?, String>(
-  (ref, itemId) async {
-    if (ref.watch(isOfflineProvider)) return null;
-    final client = ref.watch(mediaServerClientProvider);
-    try {
-      return await client.getLyrics(itemId);
-    } on DioException catch (e) {
-      final status = e.response?.statusCode;
-      if (status == 404 || status == 400) return null;
-      log(e.message ?? 'Error while fetching lyrics for $itemId');
-      rethrow;
-    }
-  },
-);
+final lyricsProvider = FutureProviderFamily<Lyrics?, String>((ref, itemId) {
+  if (ref.watch(isOfflineProvider)) return Future.value();
+  final client = ref.watch(mediaServerClientProvider);
+  if (!client.capabilities.lyrics) return Future.value();
+  return client.getLyrics(itemId);
+});
 
 final lyricsVisibleProvider = StateProvider<bool>((ref) => false);
 

--- a/lib/src/domain/providers/search_items_providers.dart
+++ b/lib/src/domain/providers/search_items_providers.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:jplayer/src/core/enums/enums.dart';
 import 'package:jplayer/src/core/exceptions/exceptions.dart';
+import 'package:jplayer/src/data/backend/library_query.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
 import 'package:jplayer/src/domain/models/models.dart';
@@ -28,35 +29,28 @@ class SearchItemsNotifier
     _searchTerm = searchQuery ?? '';
     if (_searchTerm.isEmpty) return const ItemsPage();
 
-    final userId = ref.read(currentUserProvider)!.userId;
     final libraryId = ref.read(currentLibraryProvider).valueOrNull?.id;
 
     switch (arg) {
       case ItemList.songs:
         final resp = await _client.searchSongs(
-          userId: userId,
-          libraryId: libraryId,
-          searchTerm: _searchTerm,
+          SearchQuery(term: _searchTerm, libraryId: libraryId),
         );
         return ItemsPage(items: resp.items);
       case ItemList.artists:
         final resp = await _client.searchArtists(
-          userId: userId,
-          searchTerm: _searchTerm,
+          SearchQuery(term: _searchTerm),
         );
         return ItemsPage(items: resp.items);
       case ItemList.playlists:
+        if (!_client.capabilities.playlistSearch) return const ItemsPage();
         final resp = await _client.searchPlaylists(
-          userId: userId,
-          libraryId: libraryId ?? '',
-          searchTerm: _searchTerm,
+          SearchQuery(term: _searchTerm, libraryId: libraryId),
         );
         return ItemsPage(items: resp.items);
       default:
         final resp = await _client.searchAlbums(
-          userId: userId,
-          libraryId: libraryId,
-          searchTerm: _searchTerm,
+          SearchQuery(term: _searchTerm, libraryId: libraryId),
         );
         return ItemsPage(items: resp.items);
     }

--- a/lib/src/domain/providers/set_playback_provider.dart
+++ b/lib/src/domain/providers/set_playback_provider.dart
@@ -1,12 +1,15 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jplayer/src/data/backend/library_query.dart';
 import 'package:jplayer/src/data/providers/download_database_provider.dart';
 import 'package:jplayer/src/data/providers/media_server_client_provider.dart';
 import 'package:jplayer/src/domain/models/models.dart';
 import 'package:jplayer/src/domain/providers/current_library_provider.dart';
-import 'package:jplayer/src/domain/providers/current_user_provider.dart';
 import 'package:jplayer/src/domain/providers/playback_provider.dart';
 import 'package:jplayer/src/domain/providers/todays_playlists_provider.dart';
 import 'package:jplayer/src/providers/connectivity_provider.dart';
+
+const _setSongsLimit = 300;
+const _favouriteSongsLimit = 500;
 
 enum SetPlaybackResult {
   started,
@@ -19,8 +22,6 @@ class SetPlaybackNotifier extends StateNotifier<String?> {
 
   final Ref _ref;
 
-  String get _userId => _ref.read(currentUserProvider)!.userId;
-
   Future<SetPlaybackResult> playAlbum(LibraryItem album) => _play(
     setItem: album,
     fetchSongs: () => _albumSongs(album.id),
@@ -31,7 +32,7 @@ class SetPlaybackNotifier extends StateNotifier<String?> {
       try {
         final resp = await _ref
             .read(mediaServerClientProvider)
-            .getSongs(userId: _userId, albumId: albumId);
+            .getSongs(albumId);
         return _byIndexNumber(resp.items);
       } on Object {}
     }
@@ -49,7 +50,13 @@ class SetPlaybackNotifier extends StateNotifier<String?> {
     fetchSongs: () async {
       final resp = await _ref
           .read(mediaServerClientProvider)
-          .getSongsOfSet(userId: _userId, artistIds: [artist.id]);
+          .getSongsOfSet(
+            LibraryQuery(
+              artistIds: [artist.id],
+              sort: ItemSort.albumOrder,
+              limit: _setSongsLimit,
+            ),
+          );
       return resp.items;
     },
   );
@@ -60,9 +67,12 @@ class SetPlaybackNotifier extends StateNotifier<String?> {
       final resp = await _ref
           .read(mediaServerClientProvider)
           .getSongsOfSet(
-            userId: _userId,
-            libraryId: _ref.read(currentLibraryProvider).valueOrNull?.id,
-            genreIds: [genre.id],
+            LibraryQuery(
+              libraryId: _ref.read(currentLibraryProvider).valueOrNull?.id,
+              genreIds: [genre.id],
+              sort: ItemSort.albumOrder,
+              limit: _setSongsLimit,
+            ),
           );
       return resp.items;
     },
@@ -88,7 +98,7 @@ class SetPlaybackNotifier extends StateNotifier<String?> {
       try {
         final resp = await _ref
             .read(mediaServerClientProvider)
-            .getPlaylistSongs(playlistId: playlistId, userId: _userId);
+            .getPlaylistSongs(playlistId);
         return resp.items;
       } on Object {}
     }
@@ -105,10 +115,11 @@ class SetPlaybackNotifier extends StateNotifier<String?> {
           final resp = await _ref
               .read(mediaServerClientProvider)
               .getAllSongs(
-                userId: _userId,
-                libraryId: _ref.read(currentLibraryProvider).valueOrNull?.id,
-                filters: const ['IsFavorite'],
-                limit: '500',
+                LibraryQuery(
+                  libraryId: _ref.read(currentLibraryProvider).valueOrNull?.id,
+                  filters: const {ItemFilterFlag.favorite},
+                  limit: _favouriteSongsLimit,
+                ),
               );
           return resp.items;
         },

--- a/lib/src/domain/providers/similar_albums_provider.dart
+++ b/lib/src/domain/providers/similar_albums_provider.dart
@@ -11,8 +11,9 @@ similarAlbumsProvider = FutureProvider.autoDispose
       final user = ref.watch(currentUserProvider);
       if (user == null) return const [];
 
-      final response = await ref
-          .watch(mediaServerClientProvider)
-          .getSimilarAlbums(albumId: albumId, userId: user.userId);
+      final client = ref.watch(mediaServerClientProvider);
+      if (!client.capabilities.similarAlbums) return const [];
+
+      final response = await client.getSimilarAlbums(albumId);
       return response.items.where((album) => album.id != albumId).toList();
     });

--- a/lib/src/domain/providers/todays_playlists_provider.dart
+++ b/lib/src/domain/providers/todays_playlists_provider.dart
@@ -34,7 +34,6 @@ Future<List<LibraryItem>> loadGeneratedPlaylistSongs(
   final songs = await ref
       .read(mediaServerClientProvider)
       .getGeneratedPlaylistSongs(
-        userId: userId,
         playlistId: playlistId,
         libraryId: libraryId,
       );
@@ -96,7 +95,6 @@ class TodaysPlaylistsNotifier
     final playlists = await ref
         .read(mediaServerClientProvider)
         .generateTodaysPlaylists(
-          userId: userId,
           libraryId: libraryId,
           includeDiscovery: true,
         );

--- a/lib/src/presentation/pages/album_page.dart
+++ b/lib/src/presentation/pages/album_page.dart
@@ -164,10 +164,7 @@ class _AlbumPageState extends ConsumerState<AlbumPage> {
     try {
       final response = await ref
           .read(mediaServerClientProvider)
-          .getSongs(
-            userId: ref.read(currentUserProvider)!.userId,
-            albumId: widget.album.id,
-          );
+          .getSongs(widget.album.id);
       if (!mounted) return;
       setState(() {
         songs = _sortedByIndex(response.items);
@@ -435,7 +432,7 @@ class _AlbumPageState extends ConsumerState<AlbumPage> {
                       onPressed: () async {
                         final item = await ref
                             .read(mediaServerClientProvider)
-                            .getItem(a.id);
+                            .getItem(a.id, kind: ItemKind.artist);
                         if (!mounted) return;
                         await context.pushNamed(
                           branchAwareName(context, Routes.artist),

--- a/lib/src/presentation/pages/artist_page.dart
+++ b/lib/src/presentation/pages/artist_page.dart
@@ -4,10 +4,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:jplayer/src/config/routes.dart';
+import 'package:jplayer/src/data/backend/library_query.dart';
 import 'package:jplayer/src/data/backend/stream_source.dart';
 import 'package:jplayer/src/domain/models/models.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
-import 'package:jplayer/src/domain/providers/current_user_provider.dart';
 import 'package:jplayer/src/domain/providers/set_playback_provider.dart';
 import 'package:jplayer/src/presentation/utils/utils.dart';
 import 'package:jplayer/src/presentation/widgets/widgets.dart';
@@ -64,9 +64,11 @@ class _ArtistPageState extends ConsumerState<ArtistPage> {
     final resp = await ref
         .read(mediaServerClientProvider)
         .getAlbums(
-          userId: ref.read(currentUserProvider)!.userId,
-          libraryId: '',
-          contributingArtistIds: widget.artist.id,
+          LibraryQuery(
+            sort: ItemSort.dateCreated,
+            direction: SortDirection.descending,
+            appearsOnArtistId: widget.artist.id,
+          ),
         );
     setState(() {
       _appearsOn = resp.items;
@@ -77,9 +79,11 @@ class _ArtistPageState extends ConsumerState<ArtistPage> {
     final resp = await ref
         .read(mediaServerClientProvider)
         .getAlbums(
-          userId: ref.read(currentUserProvider)!.userId,
-          libraryId: '',
-          artistIds: [widget.artist.id],
+          LibraryQuery(
+            sort: ItemSort.dateCreated,
+            direction: SortDirection.descending,
+            artistIds: [widget.artist.id],
+          ),
         );
     setState(() {
       _albums = resp.items;

--- a/lib/src/presentation/pages/browse_page.dart
+++ b/lib/src/presentation/pages/browse_page.dart
@@ -109,7 +109,9 @@ class _BrowsePageState extends ConsumerState<BrowsePage>
   Future<void> _onSongGoToAlbum(LibraryItem song) async {
     final albumId = song.albumId;
     if (albumId == null) return;
-    final item = await ref.read(mediaServerClientProvider).getItem(albumId);
+    final item = await ref
+        .read(mediaServerClientProvider)
+        .getItem(albumId, kind: ItemKind.album);
     if (!mounted) return;
     _onAlbumTap(item);
   }
@@ -117,7 +119,9 @@ class _BrowsePageState extends ConsumerState<BrowsePage>
   Future<void> _onSongArtistTap(LibraryItem song) async {
     final artistId = song.effectiveArtists.firstOrNull?.id;
     if (artistId == null) return;
-    final item = await ref.read(mediaServerClientProvider).getItem(artistId);
+    final item = await ref
+        .read(mediaServerClientProvider)
+        .getItem(artistId, kind: ItemKind.artist);
     if (!mounted) return;
     context.pushNamed(Routes.artist.name, extra: {'artist': item});
   }

--- a/lib/src/presentation/pages/playlist_page.dart
+++ b/lib/src/presentation/pages/playlist_page.dart
@@ -7,10 +7,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:jplayer/resources/j_player_icons.dart';
 import 'package:jplayer/src/config/routes.dart';
+import 'package:jplayer/src/data/backend/library_query.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
 import 'package:jplayer/src/data/services/image_service.dart';
 import 'package:jplayer/src/domain/models/models.dart';
-import 'package:jplayer/src/domain/providers/current_user_provider.dart';
 import 'package:jplayer/src/domain/providers/download_manager_provider.dart';
 import 'package:jplayer/src/domain/providers/is_playlist_downloaded_provider.dart';
 import 'package:jplayer/src/domain/providers/now_playing_provider.dart';
@@ -89,10 +89,7 @@ class _PlaylistPageState extends ConsumerState<PlaylistPage> {
     try {
       final value = await ref
           .read(mediaServerClientProvider)
-          .getPlaylistSongs(
-            userId: ref.read(currentUserProvider.notifier).state!.userId,
-            playlistId: widget.playlist.id,
-          );
+          .getPlaylistSongs(widget.playlist.id);
       if (!mounted) return;
       setState(() {
         songs = [...value.items]
@@ -274,13 +271,12 @@ class _PlaylistPageState extends ConsumerState<PlaylistPage> {
                                       final res = await ref
                                           .read(mediaServerClientProvider)
                                           .searchArtists(
-                                            userId: ref
-                                                .read(currentUserProvider)!
-                                                .userId,
-                                            searchTerm: song
-                                                .effectiveArtists
-                                                .first
-                                                .name,
+                                            SearchQuery(
+                                              term: song
+                                                  .effectiveArtists
+                                                  .first
+                                                  .name,
+                                            ),
                                           );
                                       if (context.mounted) {
                                         await context.pushNamed(
@@ -303,10 +299,7 @@ class _PlaylistPageState extends ConsumerState<PlaylistPage> {
                                       final res = await ref
                                           .read(mediaServerClientProvider)
                                           .searchAlbums(
-                                            userId: ref
-                                                .read(currentUserProvider)!
-                                                .userId,
-                                            searchTerm: song.albumName!,
+                                            SearchQuery(term: song.albumName!),
                                           );
                                       if (context.mounted) {
                                         await context.pushNamed(

--- a/lib/src/presentation/widgets/bottom_player.dart
+++ b/lib/src/presentation/widgets/bottom_player.dart
@@ -219,7 +219,7 @@ class _BottomPlayerState extends ConsumerState<BottomPlayer>
                                 currentSong!.extras!['artistId'] as String;
                             final item = await ref
                                 .read(mediaServerClientProvider)
-                                .getItem(artistId);
+                                .getItem(artistId, kind: ItemKind.artist);
                             if (!context.mounted) return;
                             Navigator.of(context).pop();
                             context.goNamed(
@@ -431,7 +431,10 @@ class _BottomPlayerState extends ConsumerState<BottomPlayer>
                                             as String;
                                     final item = await ref
                                         .read(mediaServerClientProvider)
-                                        .getItem(artistId);
+                                        .getItem(
+                                          artistId,
+                                          kind: ItemKind.artist,
+                                        );
                                     if (!context.mounted) return;
                                     context.goNamed(
                                       Routes.artist.name,
@@ -589,7 +592,9 @@ class _BottomPlayerState extends ConsumerState<BottomPlayer>
   }
 
   Future<void> _goToArtist(BuildContext sheetContext, String artistId) async {
-    final item = await ref.read(mediaServerClientProvider).getItem(artistId);
+    final item = await ref
+        .read(mediaServerClientProvider)
+        .getItem(artistId, kind: ItemKind.artist);
     if (sheetContext.mounted) Navigator.of(sheetContext).pop();
     if (!mounted) return;
     Navigator.of(context).pop();

--- a/lib/src/presentation/widgets/lyrics_overlay.dart
+++ b/lib/src/presentation/widgets/lyrics_overlay.dart
@@ -168,8 +168,8 @@ class _LyricsBodyState extends ConsumerState<_LyricsBody> {
 
     final shifted = position + lyrics.offset;
     var index = -1;
-    for (var i = 0; i < lyrics.lyrics.length; i++) {
-      final start = lyrics.lyrics[i].startTime;
+    for (var i = 0; i < lyrics.lines.length; i++) {
+      final start = lyrics.lines[i].start;
       if (start == null) continue;
       if (start > shifted) break;
       index = i;
@@ -205,7 +205,7 @@ class _LyricsBodyState extends ConsumerState<_LyricsBody> {
       ),
       error: (_, _) => const _Message("Couldn't load lyrics"),
       data: (lyrics) {
-        final lines = lyrics?.lyrics ?? const <LyricLineDTO>[];
+        final lines = lyrics?.lines ?? const <LyricLine>[];
         if (lines.isEmpty) return const _Message('No lyrics for this track');
 
         if (_lineKeys.length != lines.length) {
@@ -234,9 +234,9 @@ class _LyricsBodyState extends ConsumerState<_LyricsBody> {
     );
   }
 
-  Widget _line(int index, LyricLineDTO line, {required bool isSynced}) {
+  Widget _line(int index, LyricLine line, {required bool isSynced}) {
     final isActive = isSynced && index == _activeLine;
-    final start = line.startTime;
+    final start = line.start;
     final text = line.text.trim();
 
     return Padding(

--- a/lib/src/presentation/widgets/song_list_sliver.dart
+++ b/lib/src/presentation/widgets/song_list_sliver.dart
@@ -57,7 +57,9 @@ class _SongListSliverState extends ConsumerState<SongListSliver> {
   Future<void> _onArtistTap(LibraryItem song) async {
     final artistId = song.effectiveArtists.firstOrNull?.id;
     if (artistId == null) return;
-    final item = await ref.read(mediaServerClientProvider).getItem(artistId);
+    final item = await ref
+        .read(mediaServerClientProvider)
+        .getItem(artistId, kind: ItemKind.artist);
     if (!mounted) return;
     context.pushNamed(
       branchAwareName(context, Routes.artist),
@@ -68,7 +70,9 @@ class _SongListSliverState extends ConsumerState<SongListSliver> {
   Future<void> _onGoToAlbum(LibraryItem song) async {
     final albumId = song.albumId;
     if (albumId == null) return;
-    final item = await ref.read(mediaServerClientProvider).getItem(albumId);
+    final item = await ref
+        .read(mediaServerClientProvider)
+        .getItem(albumId, kind: ItemKind.album);
     if (!mounted) return;
     ref.read(currentAlbumProvider.notifier).setAlbum(item);
     context.pushNamed(

--- a/lib/src/providers/auth_provider.dart
+++ b/lib/src/providers/auth_provider.dart
@@ -9,14 +9,10 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:jplayer/main.dart';
 import 'package:jplayer/src/config/constants.dart';
 import 'package:jplayer/src/core/network/certificate_trust.dart';
-import 'package:jplayer/src/data/api/api.dart';
-import 'package:jplayer/src/data/backend/emby/emby_auth_headers.dart';
-import 'package:jplayer/src/data/backend/emby/emby_client.dart';
-import 'package:jplayer/src/data/backend/jellyfin/jellyfin_auth_headers.dart';
-import 'package:jplayer/src/data/backend/jellyfin/jellyfin_client.dart';
+import 'package:jplayer/src/data/backend/media_server_backends.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
+import 'package:jplayer/src/data/backend/media_server_exception.dart';
 import 'package:jplayer/src/data/backend/server_auth_headers.dart';
-import 'package:jplayer/src/data/dto/dto.dart';
 import 'package:jplayer/src/data/params/params.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
 import 'package:jplayer/src/data/services/server_probe_service.dart';
@@ -32,8 +28,10 @@ class AuthNotifier extends AsyncNotifier<bool?> {
   AuthNotifier() {
     _noAuthNetworkInterceptor = InterceptorsWrapper(
       onError: (error, handler) {
-        final statusCode = error.response?.statusCode;
-        if (statusCode == 401 && !_authenticating && !_loggingOut) logout();
+        final failure = MediaServerException.fromDio(error);
+        if (failure.isUnauthorized && !_authenticating && !_loggingOut) {
+          logout();
+        }
         handler.next(error);
       },
     );
@@ -125,13 +123,10 @@ class AuthNotifier extends AsyncNotifier<bool?> {
   }
 
   Future<ServerType> _detectServerType(String serverUrl) async {
-    final probe = ref.read(serverProbeServiceProvider);
-    final info = await probe.probe(serverUrl);
-    if (info != null) {
-      return probe.resolveServerType(info, serverUrl: serverUrl);
-    }
-    return serverTypeFromProductName(await probe.ping(serverUrl)) ??
-        ServerType.jellyfin;
+    final detected = await ref
+        .read(serverProbeServiceProvider)
+        .detectType(serverUrl);
+    return detected ?? ServerType.jellyfin;
   }
 
   Future<String?> _signIn(
@@ -141,10 +136,13 @@ class AuthNotifier extends AsyncNotifier<bool?> {
   ) async {
     try {
       _setAuthHeader(serverType);
-      final result = await _authenticate(serverType, serverUrl, credentials);
-      final token = result.accessToken;
-      final userId = result.user.id;
-      final serverId = result.serverId.isNotEmpty ? result.serverId : serverUrl;
+      final session = await authenticatorFor(
+        serverType,
+        dio: _client,
+      ).signIn(credentials, serverUrl: serverUrl);
+      final token = session.token;
+      final userId = session.userId;
+      final serverId = session.serverId;
       await _storage.write(key: _authTokenKey, value: token);
       await _storage.write(key: _userIdKey, value: userId);
       await _storage.write(key: _serverUrlKey, value: serverUrl);
@@ -172,54 +170,18 @@ class AuthNotifier extends AsyncNotifier<bool?> {
       }
       state = AsyncData(sessionUsable);
     } on DioException catch (e) {
+      return _loginErrorMessage(MediaServerException.fromDio(e), serverUrl);
+    } on MediaServerException catch (e) {
       return _loginErrorMessage(e, serverUrl);
     }
     return state.error?.toString();
   }
 
-  Future<SignInResultDTO> _authenticate(
-    ServerType serverType,
-    String serverUrl,
-    UserCredentials credentials,
-  ) async {
-    switch (serverType) {
-      case ServerType.jellyfin:
-        final response = await JellyfinApi(
-          _client,
-          baseUrl: serverUrl,
-        ).signIn(credentials: credentials);
-        return response.data;
-
-      case ServerType.emby:
-        final response = await EmbyApi(
-          _client,
-          baseUrl: serverUrl,
-        ).signIn(credentials: credentials);
-        return response.data;
-    }
-  }
-
-  String _loginErrorMessage(DioException e, String serverUrl) {
+  String _loginErrorMessage(MediaServerException e, String serverUrl) {
     if (_rejectedCertificateFor(serverUrl) != null) {
       return untrustedCertificateError;
     }
-    switch (e.type) {
-      case DioExceptionType.badResponse:
-        final statusCode = e.response?.statusCode;
-        if (statusCode == 401 || statusCode == 403) {
-          return invalidCredentialsError;
-        }
-        return serverUnreachableError;
-
-      case DioExceptionType.connectionTimeout:
-      case DioExceptionType.sendTimeout:
-      case DioExceptionType.receiveTimeout:
-      case DioExceptionType.connectionError:
-      case DioExceptionType.badCertificate:
-      case DioExceptionType.cancel:
-      case DioExceptionType.unknown:
-        return serverUnreachableError;
-    }
+    return e.isUnauthorized ? invalidCredentialsError : serverUnreachableError;
   }
 
   ServerCertificate? _rejectedCertificateFor(String serverUrl) {
@@ -273,8 +235,10 @@ class AuthNotifier extends AsyncNotifier<bool?> {
 
     // TODO: Remove in 2.5.0, tis is one time thing to adopt dowmloads without serverId
 
-    final info = await ref.read(serverProbeServiceProvider).probe(serverUrl);
-    final serverId = info?.id;
+    final identity = await ref
+        .read(serverProbeServiceProvider)
+        .probe(serverUrl);
+    final serverId = identity?.serverId;
     if (serverId == null || serverId.isEmpty) return null;
 
     await _storage.write(key: _serverIdKey, value: serverId);
@@ -320,27 +284,14 @@ class AuthNotifier extends AsyncNotifier<bool?> {
     required String serverUrl,
     required String userId,
     required String token,
-  }) {
-    switch (serverType) {
-      case ServerType.jellyfin:
-        return JellyfinClient(
-          dio: _client,
-          baseUrl: serverUrl,
-          userId: userId,
-          token: token,
-          deviceId: deviceId,
-        );
-
-      case ServerType.emby:
-        return EmbyClient(
-          dio: _client,
-          baseUrl: serverUrl,
-          userId: userId,
-          token: token,
-          deviceId: deviceId,
-        );
-    }
-  }
+  }) => clientFor(
+    serverType,
+    dio: _client,
+    baseUrl: serverUrl,
+    userId: userId,
+    token: token,
+    deviceId: deviceId,
+  );
 
   ServerType _parseServerType(String? stored) =>
       ServerType.values.asNameMap()[stored] ?? ServerType.jellyfin;
@@ -396,21 +347,12 @@ class AuthNotifier extends AsyncNotifier<bool?> {
     if (kDebugMode) _notifyDeveloper();
   }
 
-  ServerAuthHeaders _authHeadersOf(ServerType serverType) {
-    final deviceName = getCurrentPlatformName();
-    return switch (serverType) {
-      ServerType.jellyfin => JellyfinAuthHeaders(
-        deviceId: deviceId,
-        deviceName: deviceName,
-        version: version,
-      ),
-      ServerType.emby => EmbyAuthHeaders(
-        deviceId: deviceId,
-        deviceName: deviceName,
-        version: version,
-      ),
-    };
-  }
+  ServerAuthHeaders _authHeadersOf(ServerType serverType) => authHeadersFor(
+    serverType,
+    deviceId: deviceId,
+    deviceName: getCurrentPlatformName(),
+    version: version,
+  );
 
   void _notifyDeveloper() => log(
     {

--- a/test/data/backend/emby/emby_client_test.dart
+++ b/test/data/backend/emby/emby_client_test.dart
@@ -300,12 +300,12 @@ void main() {
 
       final lyrics = await lyricsClient.getLyrics('57');
 
-      expect(lyrics.isSynced, isTrue);
-      expect(lyrics.lyrics.map((line) => line.text), ['Yeah!', 'second line']);
-      expect(lyrics.lyrics.first.startTime, const Duration(milliseconds: 2400));
+      expect(lyrics!.isSynced, isTrue);
+      expect(lyrics.lines.map((line) => line.text), ['Yeah!', 'second line']);
+      expect(lyrics.lines.first.start, const Duration(milliseconds: 2400));
     });
 
-    test('- returns empty lyrics without a second request when the song '
+    test('- returns no lyrics without a second request when the song '
         'has no lyric stream', () async {
       respond([
         {'Index': 0, 'Type': 'Audio', 'Codec': 'flac'},
@@ -313,7 +313,7 @@ void main() {
 
       final lyrics = await lyricsClient.getLyrics('57');
 
-      expect(lyrics.lyrics, isEmpty);
+      expect(lyrics, isNull);
       verify(() => mockAdapter.fetch(any(), any(), any())).called(1);
     });
   });

--- a/test/data/backend/jellyfin/jellyfin_client_test.dart
+++ b/test/data/backend/jellyfin/jellyfin_client_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jplayer/src/core/audio/stream_target_profile.dart';
@@ -6,9 +9,17 @@ import 'package:jplayer/src/data/backend/mappers/item_dto_mapper.dart';
 import 'package:jplayer/src/data/backend/stream_source.dart';
 import 'package:jplayer/src/data/dto/dto.dart';
 import 'package:jplayer/src/domain/models/models.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockHttpClientAdapter extends Mock implements HttpClientAdapter {}
 
 void main() {
   late JellyfinClient client;
+
+  setUpAll(() {
+    registerFallbackValue(RequestOptions(path: '/'));
+    registerFallbackValue(const Stream<Uint8List>.empty());
+  });
 
   setUp(() {
     client = JellyfinClient(
@@ -56,6 +67,74 @@ void main() {
     kind: ItemKind.album,
     images: ImageRefs(primary: primary, backdrops: backdrops),
   );
+
+  group('getLyrics', () {
+    late MockHttpClientAdapter mockAdapter;
+    late JellyfinClient lyricsClient;
+
+    setUp(() {
+      mockAdapter = MockHttpClientAdapter();
+      lyricsClient = JellyfinClient(
+        dio: Dio()..httpClientAdapter = mockAdapter,
+        baseUrl: 'http://jelly.local:8096',
+        userId: 'user-1',
+        token: 'token-1',
+        deviceId: 'device-1',
+      );
+    });
+
+    void respondWith(int statusCode, Object? body) {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenAnswer(
+        (_) async => ResponseBody.fromString(
+          jsonEncode(body),
+          statusCode,
+          headers: {
+            Headers.contentTypeHeader: [Headers.jsonContentType],
+          },
+        ),
+      );
+    }
+
+    test('- maps the payload onto synced lyrics', () async {
+      respondWith(200, {
+        'Metadata': {'IsSynced': true},
+        'Lyrics': [
+          {'Text': 'first line', 'Start': 0},
+          {'Text': 'second line', 'Start': 100000000},
+        ],
+      });
+
+      final lyrics = await lyricsClient.getLyrics('song-1');
+
+      expect(lyrics!.isSynced, isTrue);
+      expect(lyrics.lines.map((line) => line.text), [
+        'first line',
+        'second line',
+      ]);
+      expect(lyrics.lines.last.start, const Duration(seconds: 10));
+    });
+
+    test('- returns null when the track has no lyrics', () async {
+      respondWith(404, {'error': 'not found'});
+
+      expect(await lyricsClient.getLyrics('song-1'), isNull);
+    });
+
+    test('- returns null when the server predates the endpoint', () async {
+      respondWith(400, {'error': 'bad request'});
+
+      expect(await lyricsClient.getLyrics('song-1'), isNull);
+    });
+
+    test('- surfaces any other failure', () async {
+      respondWith(500, {'error': 'boom'});
+
+      await expectLater(
+        lyricsClient.getLyrics('song-1'),
+        throwsA(isA<DioException>()),
+      );
+    });
+  });
 
   group('resolveStreamSource', () {
     test(

--- a/test/data/backend/jellyfin/jellyfin_playlist_generator_test.dart
+++ b/test/data/backend/jellyfin/jellyfin_playlist_generator_test.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jplayer/src/data/backend/jellyfin/jellyfin_playlist_generator.dart';
+import 'package:jplayer/src/data/backend/library_query.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
 import 'package:jplayer/src/domain/models/models.dart';
 import 'package:mocktail/mocktail.dart';
@@ -11,7 +12,10 @@ class MockMediaServerClient extends Mock implements MediaServerClient {}
 void main() {
   late MockMediaServerClient mockClient;
 
-  setUpAll(() => registerFallbackValue(<String>[]));
+  setUpAll(() {
+    registerFallbackValue(<String>[]);
+    registerFallbackValue(const LibraryQuery());
+  });
 
   setUp(() => mockClient = MockMediaServerClient());
 
@@ -46,54 +50,23 @@ void main() {
 
   void stubScan(List<LibraryItem> songs) {
     when(
-      () => mockClient.getAllSongs(
-        userId: any(named: 'userId'),
-        libraryId: any(named: 'libraryId'),
-        startIndex: any(named: 'startIndex'),
-        limit: any(named: 'limit'),
-        sortBy: any(named: 'sortBy'),
-        sortOrder: any(named: 'sortOrder'),
-        filters: any(named: 'filters'),
-        fields: any(named: 'fields'),
-      ),
+      () => mockClient.getAllSongs(any()),
     ).thenAnswer((_) async => LibraryPage(items: songs));
   }
 
   void stubGenres(List<LibraryItem> genres) {
     when(
-      () => mockClient.getGenres(
-        userId: any(named: 'userId'),
-        libraryId: any(named: 'libraryId'),
-        startIndex: any(named: 'startIndex'),
-        limit: any(named: 'limit'),
-        sortBy: any(named: 'sortBy'),
-        sortOrder: any(named: 'sortOrder'),
-      ),
+      () => mockClient.getGenres(any()),
     ).thenAnswer((_) async => LibraryPage(items: genres));
   }
 
   void stubSongsOfSet(
-    LibraryPage Function(List<String> genreIds, List<String> filters) respond,
+    LibraryPage Function(List<String> genreIds, Set<ItemFilterFlag> filters)
+    respond,
   ) {
-    when(
-      () => mockClient.getSongsOfSet(
-        userId: any(named: 'userId'),
-        libraryId: any(named: 'libraryId'),
-        artistIds: any(named: 'artistIds'),
-        genreIds: any(named: 'genreIds'),
-        filters: any(named: 'filters'),
-        sortBy: any(named: 'sortBy'),
-        sortOrder: any(named: 'sortOrder'),
-        startIndex: any(named: 'startIndex'),
-        limit: any(named: 'limit'),
-        fields: any(named: 'fields'),
-      ),
-    ).thenAnswer((invocation) async {
-      final args = invocation.namedArguments;
-      return respond(
-        args[const Symbol('genreIds')] as List<String>,
-        args[const Symbol('filters')] as List<String>,
-      );
+    when(() => mockClient.getSongsOfSet(any())).thenAnswer((invocation) async {
+      final query = invocation.positionalArguments.first as LibraryQuery;
+      return respond(query.genreIds, query.filters);
     });
   }
 
@@ -102,7 +75,6 @@ void main() {
     int seed = 1,
   }) => generateJellyfinTodaysPlaylists(
     mockClient,
-    userId: 'user-1',
     includeDiscovery: includeDiscovery,
     random: Random(seed),
   );
@@ -190,14 +162,7 @@ void main() {
 
       expect(await generate(), isEmpty);
       verifyNever(
-        () => mockClient.getGenres(
-          userId: any(named: 'userId'),
-          libraryId: any(named: 'libraryId'),
-          startIndex: any(named: 'startIndex'),
-          limit: any(named: 'limit'),
-          sortBy: any(named: 'sortBy'),
-          sortOrder: any(named: 'sortOrder'),
-        ),
+        () => mockClient.getGenres(any()),
       );
     });
 
@@ -280,7 +245,7 @@ void main() {
     test('- gate on unplayed songs, not total songs', () async {
       stubOneMainAndSpareGenres();
       stubSongsOfSet(
-        (genreIds, filters) => filters.contains('IsUnplayed')
+        (genreIds, filters) => filters.contains(ItemFilterFlag.unplayed)
             ? pool(genreIds.first, albums: 2)
             : pool(genreIds.first, albums: 40),
       );
@@ -341,7 +306,6 @@ void main() {
 
       final songs = await fetchJellyfinGeneratedPlaylistSongs(
         mockClient,
-        userId: 'user-1',
         playlistId: jellyfinGenreMixId(const ['alt-1', 'alt-2']),
         random: Random(1),
       );
@@ -356,7 +320,7 @@ void main() {
       var calls = 0;
       stubSongsOfSet((genreIds, filters) {
         calls++;
-        expect(filters, ['IsUnplayed']);
+        expect(filters, {ItemFilterFlag.unplayed});
         return LibraryPage(
           items: [for (var i = 1; i <= 30; i++) song('n$i')],
         );
@@ -364,7 +328,6 @@ void main() {
 
       final songs = await fetchJellyfinGeneratedPlaylistSongs(
         mockClient,
-        userId: 'user-1',
         playlistId: jellyfinGenreDiscoveryId(const ['jazz-id']),
         random: Random(1),
       );
@@ -377,7 +340,6 @@ void main() {
     test('- refuses a playlist id it did not mint', () async {
       final songs = await fetchJellyfinGeneratedPlaylistSongs(
         mockClient,
-        userId: 'user-1',
         playlistId: 'navidrome:something-else',
         random: Random(1),
       );

--- a/test/data/services/server_probe_service_test.dart
+++ b/test/data/services/server_probe_service_test.dart
@@ -295,6 +295,40 @@ void main() {
     });
   });
 
+  group('ServerProbeService.detectType', () {
+    test('- falls back to the ping product name when the public info '
+        'is unavailable', () async {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenAnswer((
+        invocation,
+      ) async {
+        final options = invocation.positionalArguments.first as RequestOptions;
+        if (options.uri.path.endsWith('/System/Ping')) {
+          return ResponseBody.fromString(
+            'Emby Server',
+            200,
+            headers: {
+              Headers.contentTypeHeader: ['text/plain'],
+            },
+          );
+        }
+        return jsonBody({'error': 'nope'}, 404);
+      });
+
+      expect(await service.detectType('http://media.local'), ServerType.emby);
+    });
+
+    test('- has no answer when neither the info nor the ping does', () async {
+      when(() => mockAdapter.fetch(any(), any(), any())).thenThrow(
+        DioException.connectionError(
+          requestOptions: RequestOptions(path: '/System/Ping'),
+          reason: 'refused',
+        ),
+      );
+
+      expect(await service.detectType('http://media.local'), isNull);
+    });
+  });
+
   group('serverPathCandidates', () {
     test('- tries the root then the /emby prefix', () {
       expect(serverPathCandidates('http://media.local:8096'), [
@@ -335,7 +369,7 @@ void main() {
         final info = await service.probe('http://jelly.local');
 
         expect(info, isNotNull);
-        expect(info!.serverName, 'Living Room');
+        expect(info!.name, 'Living Room');
         expect(info.version, '10.9.11');
       },
     );
@@ -350,7 +384,7 @@ void main() {
       final captured =
           verify(
                 () => mockAdapter.fetch(captureAny(), any(), any()),
-              ).captured.single
+              ).captured.first
               as RequestOptions;
       expect(captured.uri.toString(), 'http://jelly.local/System/Info/Public');
       expect(captured.method, 'GET');

--- a/test/domain/providers/discovered_servers_provider_test.dart
+++ b/test/domain/providers/discovered_servers_provider_test.dart
@@ -34,18 +34,16 @@ void main() {
     sourceAddress: sourceAddress,
   );
 
-  ServerProbeResult probeResult({
+  ServerIdentity probeResult({
     String serverUrl = 'http://192.168.1.10:8096',
     ServerType serverType = ServerType.jellyfin,
     String? serverName = 'Living Room',
-  }) => ServerProbeResult(
+  }) => ServerIdentity(
     serverUrl: serverUrl,
     serverType: serverType,
-    info: PublicSystemInfoDTO(
-      id: 'server-id',
-      serverName: serverName,
-      version: '10.9.11',
-    ),
+    serverId: 'server-id',
+    name: serverName,
+    version: '10.9.11',
   );
 
   void announces(List<ServerAnnouncement> announcements) {

--- a/test/domain/providers/lyrics_provider_test.dart
+++ b/test/domain/providers/lyrics_provider_test.dart
@@ -1,7 +1,9 @@
-import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/data/backend/mappers/lyrics_dto_mapper.dart';
+import 'package:jplayer/src/data/backend/media_server_capabilities.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
+import 'package:jplayer/src/data/backend/media_server_exception.dart';
 import 'package:jplayer/src/data/dto/dto.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
 import 'package:jplayer/src/domain/models/models.dart';
@@ -32,16 +34,6 @@ PlaybackState _playing(List<LibraryItem> songs, int index) => PlaybackState(
   currentMediaIndex: index,
 );
 
-DioException _failure(int? statusCode) {
-  final options = RequestOptions(path: '/Audio/song-1/Lyrics');
-  return DioException(
-    requestOptions: options,
-    response: statusCode == null
-        ? null
-        : Response<dynamic>(requestOptions: options, statusCode: statusCode),
-  );
-}
-
 void main() {
   late MockMediaServerClient mockClient;
 
@@ -51,7 +43,7 @@ void main() {
       {'Text': 'first line', 'Start': 0},
       {'Text': 'second line', 'Start': 100000000},
     ],
-  });
+  }).toLyrics();
 
   ProviderContainer containerWith({PlaybackNotifier? playback}) =>
       createProviderContainer(
@@ -61,7 +53,12 @@ void main() {
         ],
       );
 
-  setUp(() => mockClient = MockMediaServerClient());
+  setUp(() {
+    mockClient = MockMediaServerClient();
+    when(
+      () => mockClient.capabilities,
+    ).thenReturn(const MediaServerCapabilities());
+  });
 
   group('lyricsProvider', () {
     test('- returns the lyrics the server sends back', () async {
@@ -76,8 +73,8 @@ void main() {
       verify(() => mockClient.getLyrics('song-1')).called(1);
     });
 
-    test('- returns null when the track has no lyrics (404)', () async {
-      when(() => mockClient.getLyrics('song-1')).thenThrow(_failure(404));
+    test('- returns null when the backend reports no lyrics', () async {
+      when(() => mockClient.getLyrics('song-1')).thenAnswer((_) async => null);
 
       await expectLater(
         containerWith().read(lyricsProvider('song-1').future),
@@ -85,24 +82,26 @@ void main() {
       );
     });
 
-    test(
-      '- returns null when the server predates the endpoint (400)',
-      () async {
-        when(() => mockClient.getLyrics('song-1')).thenThrow(_failure(400));
-
-        await expectLater(
-          containerWith().read(lyricsProvider('song-1').future),
-          completion(isNull),
-        );
-      },
-    );
-
-    test('- surfaces other failures', () async {
-      when(() => mockClient.getLyrics('song-1')).thenThrow(_failure(500));
+    test('- asks for nothing when the backend has no lyrics support', () async {
+      when(
+        () => mockClient.capabilities,
+      ).thenReturn(const MediaServerCapabilities(lyrics: false));
 
       await expectLater(
         containerWith().read(lyricsProvider('song-1').future),
-        throwsA(isA<DioException>()),
+        completion(isNull),
+      );
+      verifyNever(() => mockClient.getLyrics(any()));
+    });
+
+    test('- surfaces a backend failure', () async {
+      when(() => mockClient.getLyrics('song-1')).thenThrow(
+        const MediaServerException(MediaServerErrorKind.server),
+      );
+
+      await expectLater(
+        containerWith().read(lyricsProvider('song-1').future),
+        throwsA(isA<MediaServerException>()),
       );
     });
   });

--- a/test/domain/providers/todays_playlists_provider_test.dart
+++ b/test/domain/providers/todays_playlists_provider_test.dart
@@ -116,7 +116,6 @@ void main() {
     client = MockMediaServerClient();
     when(
       () => client.generateTodaysPlaylists(
-        userId: any(named: 'userId'),
         libraryId: any(named: 'libraryId'),
         includeDiscovery: any(named: 'includeDiscovery'),
       ),
@@ -192,7 +191,6 @@ void main() {
     expect(generationCount, 0);
     verifyNever(
       () => client.generateTodaysPlaylists(
-        userId: any(named: 'userId'),
         libraryId: any(named: 'libraryId'),
         includeDiscovery: any(named: 'includeDiscovery'),
       ),

--- a/test/presentation/pages/album_page_test.dart
+++ b/test/presentation/pages/album_page_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jplayer/main.dart';
+import 'package:jplayer/src/data/backend/media_server_capabilities.dart';
 import 'package:jplayer/src/data/backend/media_server_client.dart';
 import 'package:jplayer/src/data/backend/stream_source.dart';
 import 'package:jplayer/src/data/providers/providers.dart';
@@ -123,24 +124,20 @@ void main() {
   }
 
   Future<LibraryPage> mockGetSongs({String? albumId}) {
-    return mockMediaServerClient.getSongs(
-      userId: mockUserId,
-      albumId: albumId ?? any(named: 'albumId'),
-    );
+    return mockMediaServerClient.getSongs(albumId ?? any());
   }
 
   Future<LibraryPage> mockGetSimilarAlbums({String? albumId}) {
     return mockMediaServerClient.getSimilarAlbums(
-      albumId: albumId ?? any(named: 'albumId'),
-      userId: mockUserId,
+      albumId ?? any(),
       limit: any(named: 'limit'),
     );
   }
 
   final suggestionsHeader = find.text('You may also like');
 
-  Future<void> scrollToSuggestions(WidgetTester tester) => tester
-      .scrollUntilVisible(
+  Future<void> scrollToSuggestions(WidgetTester tester) =>
+      tester.scrollUntilVisible(
         suggestionsHeader,
         200,
         scrollable: find
@@ -170,6 +167,9 @@ void main() {
     mockUser = MockUser();
     mockDownloadManagerNotifier = MockDownloadManagerNotifier();
     mockDownloadDatabase = MockDownloadDatabase();
+    when(
+      () => mockMediaServerClient.capabilities,
+    ).thenReturn(const MediaServerCapabilities());
     when(
       () => mockMediaServerClient.imageUri(
         any(),

--- a/test/presentation/pages/artist_page_test.dart
+++ b/test/presentation/pages/artist_page_test.dart
@@ -13,6 +13,7 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../app_wrapper.dart';
 import '../../provider_container.dart';
+import 'package:jplayer/src/data/backend/library_query.dart';
 
 class MockMediaServerClient extends Mock implements MediaServerClient {}
 
@@ -77,21 +78,26 @@ void main() {
     List<String>? artistIds,
   }) {
     return mockMediaServerClient.getAlbums(
-      userId: mockUserId,
-      libraryId: any(named: 'libraryId'),
-      startIndex: any(named: 'startIndex'),
-      limit: any(named: 'limit'),
-      sortBy: any(named: 'sortBy'),
-      contributingArtistIds:
-          contributingArtistIds ?? any(named: 'contributingArtistIds'),
-      sortOrder: any(named: 'sortOrder'),
-      artistIds: artistIds ?? any(named: 'artistIds'),
+      any(
+        that: predicate<LibraryQuery>((query) {
+          if (contributingArtistIds != null &&
+              query.appearsOnArtistId != contributingArtistIds) {
+            return false;
+          }
+          if (artistIds != null &&
+              query.artistIds.join(',') != artistIds.join(',')) {
+            return false;
+          }
+          return true;
+        }),
+      ),
     );
   }
 
   setUpAll(() {
     registerFallbackValue(ImageKind.primary);
     registerFallbackValue(mockArtist);
+    registerFallbackValue(const LibraryQuery());
   });
 
   setUp(() {

--- a/test/presentation/pages/login_page_test.dart
+++ b/test/presentation/pages/login_page_test.dart
@@ -51,18 +51,16 @@ void main() {
     home: const LoginPage(),
   );
 
-  ServerProbeResult discoveryResult(
+  ServerIdentity discoveryResult(
     String serverUrl, {
     ServerType serverType = ServerType.jellyfin,
     String serverName = 'Living Room',
-  }) => ServerProbeResult(
+  }) => ServerIdentity(
     serverUrl: serverUrl,
     serverType: serverType,
-    info: PublicSystemInfoDTO(
-      id: 'server-id',
-      serverName: serverName,
-      version: '10.9.11',
-    ),
+    serverId: 'server-id',
+    name: serverName,
+    version: '10.9.11',
   );
 
   void announcesServers(List<ServerAnnouncement> announcements) {

--- a/test/presentation/pages/playlist_page_test.dart
+++ b/test/presentation/pages/playlist_page_test.dart
@@ -75,10 +75,7 @@ void main() {
   );
 
   Future<LibraryPage> mockGetPlaylistSongs({String? playlistId}) {
-    return mockMediaServerClient.getPlaylistSongs(
-      userId: mockUserId,
-      playlistId: playlistId ?? any(named: 'playlistId'),
-    );
+    return mockMediaServerClient.getPlaylistSongs(playlistId ?? any());
   }
 
   setUpAll(() {

--- a/test/presentation/widgets/lyrics_view_test.dart
+++ b/test/presentation/widgets/lyrics_view_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:jplayer/src/data/backend/mappers/lyrics_dto_mapper.dart';
 import 'package:jplayer/src/data/dto/dto.dart';
 import 'package:jplayer/src/domain/models/models.dart';
 import 'package:jplayer/src/domain/providers/providers.dart';
@@ -25,7 +26,7 @@ final _synced = LyricsDTO.fromJson({
     {'Text': 'second line', 'Start': 100000000},
     {'Text': 'third line', 'Start': 200000000},
   ],
-});
+}).toLyrics();
 
 final _unsynced = LyricsDTO.fromJson({
   'Metadata': {'IsSynced': false},
@@ -33,7 +34,7 @@ final _unsynced = LyricsDTO.fromJson({
     {'Text': 'plain one'},
     {'Text': 'plain two'},
   ],
-});
+}).toLyrics();
 
 PlaybackState _stateAt(Duration position, {bool hasLyrics = true}) =>
     PlaybackState(
@@ -60,7 +61,7 @@ void main() {
   Future<void> pumpLyricsView(
     WidgetTester tester, {
     required PlaybackState state,
-    LyricsDTO? lyrics,
+    Lyrics? lyrics,
   }) async {
     playback = FakePlaybackNotifier(state);
     final container = createProviderContainer(

--- a/test/providers/auth_provider_test.dart
+++ b/test/providers/auth_provider_test.dart
@@ -72,8 +72,10 @@ void main() {
     mockStorage = MockSecureStorage();
     mockProbe = MockServerProbeService();
     when(() => mockProbe.probe(any())).thenAnswer(
-      (_) async => const PublicSystemInfoDTO(
-        id: 'server-id-from-probe',
+      (_) async => const ServerIdentity(
+        serverUrl: 'http://jelly.local',
+        serverType: ServerType.jellyfin,
+        serverId: 'server-id-from-probe',
         version: '10.9.11',
       ),
     );
@@ -437,48 +439,26 @@ void main() {
     test(
       '- identifies the server itself when the caller has no hint',
       () async {
-        when(() => mockProbe.probe(any())).thenAnswer((_) async => null);
         when(
-          () => mockProbe.ping(any()),
-        ).thenAnswer((_) async => 'Emby Server');
+          () => mockProbe.detectType(any()),
+        ).thenAnswer((_) async => ServerType.emby);
         respondWithSuccessfulLogin();
 
         await loginWith();
 
-        verify(() => mockProbe.ping('http://jelly.local')).called(1);
+        verify(() => mockProbe.detectType('http://jelly.local')).called(1);
         verify(
           () => mockStorage.write(key: 'serverType', value: 'emby'),
         ).called(1);
       },
     );
 
-    test('- uses the public info product name when there is one', () async {
-      when(() => mockProbe.probe(any())).thenAnswer(
-        (_) async => const PublicSystemInfoDTO(id: 'a', version: '4.9.5.0'),
-      );
-      when(
-        () => mockProbe.resolveServerType(
-          any(),
-          serverUrl: any(named: 'serverUrl'),
-        ),
-      ).thenAnswer((_) async => ServerType.emby);
-      respondWithSuccessfulLogin();
-
-      await loginWith();
-
-      verifyNever(() => mockProbe.ping(any()));
-      verify(
-        () => mockStorage.write(key: 'serverType', value: 'emby'),
-      ).called(1);
-    });
-
-    test('- trusts a caller hint without probing at all', () async {
+    test('- trusts a caller hint without identifying at all', () async {
       respondWithSuccessfulLogin();
 
       await loginWith(serverType: ServerType.emby);
 
-      verifyNever(() => mockProbe.probe(any()));
-      verifyNever(() => mockProbe.ping(any()));
+      verifyNever(() => mockProbe.detectType(any()));
       verify(
         () => mockStorage.write(key: 'serverType', value: 'emby'),
       ).called(1);
@@ -487,8 +467,7 @@ void main() {
     test(
       '- falls back to Jellyfin when the server cannot be identified',
       () async {
-        when(() => mockProbe.probe(any())).thenAnswer((_) async => null);
-        when(() => mockProbe.ping(any())).thenAnswer((_) async => null);
+        when(() => mockProbe.detectType(any())).thenAnswer((_) async => null);
         respondWithSuccessfulLogin();
 
         await loginWith();


### PR DESCRIPTION
Refactored API. Moved things around.

The intention was to unify API for adding more backends. Originally everything was tied to Jellyfin names/field names. I did a round sometime ago and now I finished what was left. Mostly it was abstractizing query interfaces - so instead of passing X arguments of different data types - I pass an enum which for different backends might have different field names