### PR TITLE
Fix horizontal lis scrolling on mouse desktop devices

### DIFF
--- a/lib/src/presentation/pages/album_page.dart
+++ b/lib/src/presentation/pages/album_page.dart
@@ -566,28 +566,33 @@ class _AlbumPageState extends ConsumerState<AlbumPage> {
       SliverToBoxAdapter(
         child: SizedBox(
           height: cardHeight,
-          child: ListView.separated(
-            scrollDirection: Axis.horizontal,
-            padding: EdgeInsets.only(
-              left: horizontalPadding,
-              right: horizontalPadding,
-              bottom: 16,
-            ),
-            itemBuilder: (context, index) => SizedBox(
-              width: cardWidth,
-              child: AlbumView(
-                album: albums[index],
-                onTap: (album) => context.pushNamed(
-                  branchAwareName(context, Routes.album),
-                  extra: {'album': album},
-                ),
-                onPlayPressed: (album) =>
-                    ref.read(setPlaybackProvider.notifier).playAlbum(album),
+          child: HorizontalScrollRegion(
+            controlsHeight: cardWidth,
+            controlsInset: horizontalPadding / 2,
+            builder: (context, controller) => ListView.separated(
+              controller: controller,
+              scrollDirection: Axis.horizontal,
+              padding: EdgeInsets.only(
+                left: horizontalPadding,
+                right: horizontalPadding,
+                bottom: 16,
               ),
+              itemBuilder: (context, index) => SizedBox(
+                width: cardWidth,
+                child: AlbumView(
+                  album: albums[index],
+                  onTap: (album) => context.pushNamed(
+                    branchAwareName(context, Routes.album),
+                    extra: {'album': album},
+                  ),
+                  onPlayPressed: (album) =>
+                      ref.read(setPlaybackProvider.notifier).playAlbum(album),
+                ),
+              ),
+              separatorBuilder: (context, index) =>
+                  SizedBox(width: AlbumCardMetrics.crossAxisSpacing(_device)),
+              itemCount: albums.length,
             ),
-            separatorBuilder: (context, index) =>
-                SizedBox(width: AlbumCardMetrics.crossAxisSpacing(_device)),
-            itemCount: albums.length,
           ),
         ),
       ),

--- a/lib/src/presentation/pages/favourites_page.dart
+++ b/lib/src/presentation/pages/favourites_page.dart
@@ -8,6 +8,7 @@ import 'package:jplayer/src/domain/providers/favourites_provider.dart';
 import 'package:jplayer/src/presentation/utils/utils.dart';
 import 'package:jplayer/src/presentation/widgets/album_card_metrics.dart';
 import 'package:jplayer/src/presentation/widgets/album_view.dart';
+import 'package:jplayer/src/presentation/widgets/horizontal_scroll_region.dart';
 import 'package:jplayer/src/presentation/widgets/offline_notice.dart';
 import 'package:jplayer/src/presentation/widgets/scrollable_page_scaffold.dart';
 import 'package:jplayer/src/presentation/widgets/shimmer.dart';
@@ -161,18 +162,23 @@ class _FavouritesPageState extends ConsumerState<FavouritesPage> {
             cardWidth,
             isTablet: _device.isTablet,
           ),
-          child: ListView.separated(
-            scrollDirection: Axis.horizontal,
-            clipBehavior: Clip.none,
-            padding: EdgeInsets.zero,
-            itemCount: items.length,
-            separatorBuilder: (context, index) => SizedBox(width: spacing),
-            itemBuilder: (context, index) => SizedBox(
-              width: cardWidth,
-              child: AlbumView(
-                album: items[index],
-                showArtist: category == ItemList.artists,
-                onTap: (item) => openSearchResult(context, ref, category, item),
+          child: HorizontalScrollRegion(
+            controlsHeight: cardWidth,
+            builder: (context, controller) => ListView.separated(
+              controller: controller,
+              scrollDirection: Axis.horizontal,
+              clipBehavior: Clip.none,
+              padding: EdgeInsets.zero,
+              itemCount: items.length,
+              separatorBuilder: (context, index) => SizedBox(width: spacing),
+              itemBuilder: (context, index) => SizedBox(
+                width: cardWidth,
+                child: AlbumView(
+                  album: items[index],
+                  showArtist: category == ItemList.artists,
+                  onTap: (item) =>
+                      openSearchResult(context, ref, category, item),
+                ),
               ),
             ),
           ),

--- a/lib/src/presentation/widgets/horizontal_scroll_region.dart
+++ b/lib/src/presentation/widgets/horizontal_scroll_region.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+typedef HorizontalScrollBuilder =
+    Widget Function(BuildContext context, ScrollController controller);
+
+class HorizontalScrollRegion extends StatefulWidget {
+  const HorizontalScrollRegion({
+    required this.builder,
+    this.controlsHeight,
+    this.controlsInset = 8,
+    super.key,
+  });
+
+  final HorizontalScrollBuilder builder;
+  final double? controlsHeight;
+  final double controlsInset;
+
+  @override
+  State<HorizontalScrollRegion> createState() => _HorizontalScrollRegionState();
+}
+
+class _HorizontalScrollRegionState extends State<HorizontalScrollRegion> {
+  static const _edgeTolerance = 1.0;
+  static const _pageFraction = 0.45;
+  static const _pageDuration = Duration(milliseconds: 550);
+
+  final _controller = ScrollController();
+  final _hovered = ValueNotifier<bool>(false);
+  final _canScrollBack = ValueNotifier<bool>(false);
+  final _canScrollForward = ValueNotifier<bool>(false);
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_syncEdges);
+  }
+
+  void _syncEdges() {
+    if (!_controller.hasClients) return;
+    final position = _controller.position;
+    if (!position.hasContentDimensions || !position.hasPixels) return;
+    _canScrollBack.value =
+        position.pixels > position.minScrollExtent + _edgeTolerance;
+    _canScrollForward.value =
+        position.pixels < position.maxScrollExtent - _edgeTolerance;
+  }
+
+  bool _onMetrics(ScrollMetricsNotification notification) {
+    if (notification.metrics.axis == Axis.horizontal) _syncEdges();
+    return false;
+  }
+
+  void _onPointerSignal(PointerSignalEvent event) {
+    if (event is! PointerScrollEvent) return;
+    if (event.kind != PointerDeviceKind.mouse) return;
+    if (HardwareKeyboard.instance.isShiftPressed) return;
+    final delta = event.scrollDelta;
+    if (delta.dy == 0 || delta.dx != 0) return;
+    if (!_controller.hasClients) return;
+
+    final position = _controller.position;
+    if (!position.hasContentDimensions) return;
+    final target = (position.pixels + delta.dy).clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+    if (target == position.pixels) return;
+
+    GestureBinding.instance.pointerSignalResolver.register(
+      event,
+      (_) => position.pointerScroll(delta.dy),
+    );
+  }
+
+  void _page(int direction) {
+    if (!_controller.hasClients) return;
+    final position = _controller.position;
+    final step = position.viewportDimension * _pageFraction;
+    final target = (position.pixels + step * direction).clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+    _controller.animateTo(
+      target,
+      duration: _pageDuration,
+      curve: Curves.easeOutCubic,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerSignal: _onPointerSignal,
+      child: MouseRegion(
+        onEnter: (_) => _hovered.value = true,
+        onExit: (_) => _hovered.value = false,
+        child: NotificationListener<ScrollMetricsNotification>(
+          onNotification: _onMetrics,
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              widget.builder(context, _controller),
+              _control(
+                alignment: Alignment.centerLeft,
+                enabled: _canScrollBack,
+                icon: Icons.chevron_left,
+                onPressed: () => _page(-1),
+              ),
+              _control(
+                alignment: Alignment.centerRight,
+                enabled: _canScrollForward,
+                icon: Icons.chevron_right,
+                onPressed: () => _page(1),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _control({
+    required Alignment alignment,
+    required ValueNotifier<bool> enabled,
+    required IconData icon,
+    required VoidCallback onPressed,
+  }) {
+    final button = _EdgeChevron(icon: icon, onPressed: onPressed);
+    final visibility = ValueListenableBuilder(
+      valueListenable: _hovered,
+      builder: (context, hovered, child) => ValueListenableBuilder(
+        valueListenable: enabled,
+        builder: (context, canScroll, child) {
+          final visible = hovered && canScroll;
+          return IgnorePointer(
+            ignoring: !visible,
+            child: AnimatedOpacity(
+              opacity: visible ? 1 : 0,
+              duration: const Duration(milliseconds: 300),
+              child: child,
+            ),
+          );
+        },
+        child: child,
+      ),
+      child: button,
+    );
+
+    return Positioned(
+      left: alignment.x < 0 ? widget.controlsInset : null,
+      right: alignment.x > 0 ? widget.controlsInset : null,
+      top: 0,
+      bottom: widget.controlsHeight == null ? 0 : null,
+      height: widget.controlsHeight,
+      child: Center(child: visibility),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller
+      ..removeListener(_syncEdges)
+      ..dispose();
+    _hovered.dispose();
+    _canScrollBack.dispose();
+    _canScrollForward.dispose();
+    super.dispose();
+  }
+}
+
+class _EdgeChevron extends StatelessWidget {
+  const _EdgeChevron({required this.icon, required this.onPressed});
+
+  final IconData icon;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: theme.colorScheme.surface.withValues(alpha: 0.85),
+      shape: const CircleBorder(),
+      elevation: 4,
+      shadowColor: Colors.black54,
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: onPressed,
+        child: SizedBox(
+          width: 40,
+          height: 40,
+          child: Icon(icon, size: 28, color: theme.colorScheme.onSurface),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/presentation/widgets/item_carousel.dart
+++ b/lib/src/presentation/widgets/item_carousel.dart
@@ -5,6 +5,7 @@ import 'package:jplayer/src/presentation/utils/utils.dart';
 import 'package:jplayer/src/presentation/widgets/album_card_metrics.dart';
 import 'package:jplayer/src/presentation/widgets/album_view.dart';
 import 'package:jplayer/src/presentation/widgets/clickable_widget.dart';
+import 'package:jplayer/src/presentation/widgets/horizontal_scroll_region.dart';
 import 'package:jplayer/src/presentation/widgets/shimmer.dart';
 
 class ItemCarousel extends StatelessWidget {
@@ -120,30 +121,35 @@ class ItemCarousel extends StatelessWidget {
 
   Widget _list(List<LibraryItem> list) => SizedBox(
     height: AlbumCardMetrics.carouselHeight(device),
-    child: ListView.separated(
-      scrollDirection: Axis.horizontal,
-      padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
-      clipBehavior: Clip.none,
-      itemCount: list.length,
-      separatorBuilder: (context, index) =>
-          SizedBox(width: AlbumCardMetrics.carouselSpacing(device)),
-      itemBuilder: (context, index) {
-        final item = list[index];
-        final builder = optionsBuilder;
-        return SizedBox(
-          width: AlbumCardMetrics.carouselWidth(device),
-          child: AlbumView(
-            album: item,
-            alignTextStart: true,
-            coverOverride: coverBuilder?.call(item),
-            onTap: onItemTap,
-            onPlayPressed: onPlayPressed,
-            optionsBuilder: builder == null
-                ? null
-                : (context) => builder(context, item),
-          ),
-        );
-      },
+    child: HorizontalScrollRegion(
+      controlsHeight: AlbumCardMetrics.carouselWidth(device),
+      controlsInset: horizontalPadding / 2,
+      builder: (context, controller) => ListView.separated(
+        controller: controller,
+        scrollDirection: Axis.horizontal,
+        padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+        clipBehavior: Clip.none,
+        itemCount: list.length,
+        separatorBuilder: (context, index) =>
+            SizedBox(width: AlbumCardMetrics.carouselSpacing(device)),
+        itemBuilder: (context, index) {
+          final item = list[index];
+          final builder = optionsBuilder;
+          return SizedBox(
+            width: AlbumCardMetrics.carouselWidth(device),
+            child: AlbumView(
+              album: item,
+              alignTextStart: true,
+              coverOverride: coverBuilder?.call(item),
+              onTap: onItemTap,
+              onPlayPressed: onPlayPressed,
+              optionsBuilder: builder == null
+                  ? null
+                  : (context) => builder(context, item),
+            ),
+          );
+        },
+      ),
     ),
   );
 

--- a/lib/src/presentation/widgets/search_results_sliver.dart
+++ b/lib/src/presentation/widgets/search_results_sliver.dart
@@ -9,6 +9,7 @@ import 'package:jplayer/src/presentation/utils/utils.dart';
 import 'package:jplayer/src/presentation/widgets/album_card_metrics.dart';
 import 'package:jplayer/src/presentation/widgets/album_view.dart';
 import 'package:jplayer/src/presentation/widgets/clickable_widget.dart';
+import 'package:jplayer/src/presentation/widgets/horizontal_scroll_region.dart';
 import 'package:jplayer/src/presentation/widgets/offline_notice.dart';
 import 'package:jplayer/src/presentation/widgets/search_songs_sliver.dart';
 import 'package:jplayer/src/presentation/widgets/shimmer.dart';
@@ -147,18 +148,22 @@ class SearchResultsSliver extends ConsumerWidget {
     return SliverToBoxAdapter(
       child: SizedBox(
         height: AlbumCardMetrics.height(cardWidth, isTablet: device.isTablet),
-        child: ListView.separated(
-          scrollDirection: Axis.horizontal,
-          clipBehavior: Clip.none,
-          padding: EdgeInsets.zero,
-          itemCount: items.length,
-          separatorBuilder: (context, index) => SizedBox(width: spacing),
-          itemBuilder: (context, index) => SizedBox(
-            width: cardWidth,
-            child: AlbumView(
-              album: items[index],
-              showArtist: category == ItemList.artists,
-              onTap: (item) => openSearchResult(context, ref, category, item),
+        child: HorizontalScrollRegion(
+          controlsHeight: cardWidth,
+          builder: (context, controller) => ListView.separated(
+            controller: controller,
+            scrollDirection: Axis.horizontal,
+            clipBehavior: Clip.none,
+            padding: EdgeInsets.zero,
+            itemCount: items.length,
+            separatorBuilder: (context, index) => SizedBox(width: spacing),
+            itemBuilder: (context, index) => SizedBox(
+              width: cardWidth,
+              child: AlbumView(
+                album: items[index],
+                showArtist: category == ItemList.artists,
+                onTap: (item) => openSearchResult(context, ref, category, item),
+              ),
             ),
           ),
         ),

--- a/lib/src/presentation/widgets/widgets.dart
+++ b/lib/src/presentation/widgets/widgets.dart
@@ -18,6 +18,7 @@ export 'downloaded_album_view.dart';
 export 'flip_panel.dart';
 export 'gradient_background.dart';
 export 'gradient_panel_decoration.dart';
+export 'horizontal_scroll_region.dart';
 export 'item_carousel.dart';
 export 'item_row_view.dart';
 export 'keep_screen_awake.dart';

--- a/test/presentation/pages/home_page_test.dart
+++ b/test/presentation/pages/home_page_test.dart
@@ -269,10 +269,14 @@ void main() {
     ) async {
       await pumpHome(widgetTester);
 
-      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+      final titleChevron = find.descendant(
+        of: find.byType(ClickableWidget),
+        matching: find.byIcon(Icons.chevron_right),
+      );
+      expect(titleChevron, findsOneWidget);
       expect(
         find.ancestor(
-          of: find.byIcon(Icons.chevron_right),
+          of: titleChevron,
           matching: find.widgetWithText(ItemCarousel, 'Favourites'),
         ),
         findsOneWidget,


### PR DESCRIPTION
This PR fixes issue with regular mouses on desktop that made it impossible to scroll horizontal lists. I work on laptop and I have trackpad for my desktop, so I never tested with mouse

Well I didnt invent the wheel here - a chevron buttons on both sides of list + mouse wheel which changes scroll direction from horizontal to vertical while cursor hovered over list(thx recent medium article I saw about this, without it prob just would go with buttons)